### PR TITLE
UOP Cleanup

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1258,7 +1258,7 @@ plugins:
       - Scripts
       - Stats
   - name: 'USIPS Additional Changes.esp'
-    Priority: -1999000
+    priority: -1999000
     tag:
       - Relev
   - name: 'Unofficial Shivering Isles Patch DV.esp'


### PR DESCRIPTION
Some cleanup to make the unofficial patches load in the correct order.
Setting to load UOP after Shivering Isles not needed; loose files from
UOP will overwrite Russian GOTY version of the esp. Knights made to load
last due to CTDs in some setups if it is not the last official plugin.
