### PR TITLE
Update masterlist.yaml

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22688,6 +22688,8 @@ plugins:
       - NpcFaces
       - R.Head
       - R.Mouth
+    after:
+      - 'MaleBodyReplacerV5.esp'
     url: [ 'http://www.nexusmods.com/oblivion/mods/43612' ]
   - name: 'Jjiinx_Long Ears.esp'
     tag:


### PR DESCRIPTION
Oblivion_Character_Overhaul.esp must be loaded after any other character overhaul mod.
