### PR TITLE
DeadlyReflex 6 - Remove REQ Rule for HeX NifSE Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16760,8 +16760,6 @@ plugins:
   - name: 'DeadlyReflex 6 - Combat Moves.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/8273' ]
     req:
-      - name: 'Deadly Reflex 6 - HeX NifSE Patch.esp'
-        display: 'To use both DR6b101 and NifSE 1.0+ you need the [fix file](http://www.nexusmods.com/oblivion/mods/40336).'
       - name: 'obse/plugins/NifSE.dll'
         display: '[NifSE](http://www.nexusmods.com/oblivion/mods/21292)'
       - name: 'DropLitTorchOBSE.esp'


### PR DESCRIPTION
Deadly Reflex 6 - HeX NifSE Patch.esp was made a requirement of DeadlyReflex 6 - Combat Moves.esp. 

Deadly Reflex 6 - HeX NifSE Patch.esp has DeadlyReflex 6 - Combat Moves.esp as a master and needs to be sorted after, not before. (See https://www.nexusmods.com/oblivion/mods/40336)

Currently this is causing LOOT to throw an error on sorting.

Failed to sort plugins. Details: Cyclic interaction detected between "Deadly Reflex 6 - HeX NifSE Patch.esp" and "DeadlyReflex 6 - Combat Moves.esp":

Deadly Reflex 6 - HeX NifSE Patch.esp
 [Masterlist Requirement]
DeadlyReflex 6 - Combat Moves.esp
 [Master]
Deadly Reflex 6 - HeX NifSE Patch.esp

Tested removal of 2 lines on my local machine and that fixes the sorting error.