### PR TITLE
Updates for Oscuro's Oblivion Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1661,10 +1661,7 @@ plugins:
       - name: -Relations
         condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
   - name: 'Oscuro''s_Oblivion_Overhaul - Knights of Nine.esp'
-    msg:
-      - type: error
-        content: 'Use "FCOM_Knights.esp" instead.'
-        condition: *FCOMCond
+    inc: [ 'FCOM_Convergence.esm' ]
     dirty:
       - <<: *quickClean
         crc: 0x2D3B8E8F

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1625,12 +1625,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
   - name: 'Oscuro''s_Oblivion_Overhaul.esm'
     tag:
-      - Actors.Spells
-      - Graphics
-      - Invent
-      - Relations
-      - Scripts
-      - Stats
       - name: -Relations
         condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
     clean:
@@ -1640,22 +1634,6 @@ plugins:
     after: [ 'Oblivion WarCry EV.esp' ]
     msg: [ *doNotClean ]
     tag:
-      - Actors.ACBS
-      - Actors.AIData
-      - Actors.AIPackages
-      - Actors.CombatStyle
-      - Actors.Spells
-      - Actors.Stats
-      - Delev
-      - Factions
-      - Graphics
-      - Invent
-      - Names
-      - R.ChangeSpells
-      - Relations
-      - Relev
-      - Scripts
-      - Stats
       - name: -Factions
         condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
       - name: -Relations
@@ -1828,7 +1806,6 @@ plugins:
         itm: 55
   - name: 'OOOSIArcheryPatch.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46508/' ]
-    tag: [ NoMerge ]
     clean:
       - crc: 0xC52A442B
         util: 'TES4Edit v4.0.2i'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1800,7 +1800,6 @@ plugins:
     clean:
       - crc: 0xDDBB8479
         util: 'TES4Edit v4.0.2i'
-
   ### OOO Shivering Isles ###
   - name: 'OOOShiveringIsles.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46508/' ]
@@ -1838,7 +1837,6 @@ plugins:
       - <<: *alreadyInX
         subs: [ 'OOOExtended.esp' ]
         condition: 'active("OOOExtended.esp")'
-
   ### OOO Equipment Add-on ###
   - name: 'OOOEquipmentAddon.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46028/' ]
@@ -1864,7 +1862,6 @@ plugins:
     clean:
       - crc: 0xDB360623
         util: 'TES4Edit v4.0.2i'
-
   ### OOO 3rd Party Patches and Addons ###
   - name: 'Better Hunting for OOO.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/35223' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1618,9 +1618,12 @@ plugins:
     inc:
       - 'Oscuro''s_Oblivion_Overhaul.esm'
 
-### (OOO) Oscuro's Oblivion Overhaul ###
-  - name: 'Oscuro''s_Oblivion_Overhaul.esm'
+###### (OOO) Oscuro's Oblivion Overhaul ######
+  - name: 'Oscuro''s_Oblivion_Overhaul( - Knights of Nine)?\.es(m|p)'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+  - name: 'OOO-.*\.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+  - name: 'Oscuro''s_Oblivion_Overhaul.esm'
     tag:
       - Actors.Spells
       - Graphics
@@ -1634,7 +1637,6 @@ plugins:
       - crc: 0x82322ED1
         util: 'TES4Edit v4.0.2i'
   - name: 'Oscuro''s_Oblivion_Overhaul.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     after: [ 'Oblivion WarCry EV.esp' ]
     msg: [ *doNotClean ]
     tag:
@@ -1659,7 +1661,6 @@ plugins:
       - name: -Relations
         condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
   - name: 'Oscuro''s_Oblivion_Overhaul - Knights of Nine.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg:
       - type: error
         content: 'Use "FCOM_Knights.esp" instead.'
@@ -1671,53 +1672,44 @@ plugins:
         itm: 2
   ### OOO Level Rate Options
   - name: 'OOO-Level_Normal.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     clean:
       - crc: 0x295CB490
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Level_Slow.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     clean:
       - crc: 0x2D0F52CE
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Level_Stock.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     clean:
       - crc: 0xD25FFD1E
         util: 'TES4Edit v4.0.2i'
   ### OOO Respawn Rate Options
   - name: 'OOO-Respawn_Month.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *bashedPatchTweak ]
     clean:
       - crc: 0xB57F7C18
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Two_Week.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *bashedPatchTweak ]
     clean:
       - crc: 0xF6344872
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Week.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *bashedPatchTweak ]
     clean:
       - crc: 0xB4241C0D
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Year.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *bashedPatchTweak ]
     clean:
       - crc: 0x9EF9532F
         util: 'TES4Edit v4.0.2i'
   ### OOO Compatibility Options
   - name: 'OOO-Container_Trap_Instant_Effects.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     clean:
       - crc: 0x1560A30A
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Magic_Script_Effect_Fix.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     tag:
       - Graphics
       - Sound
@@ -1725,7 +1717,6 @@ plugins:
       - crc: 0x7AD033AE
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-No_Guild_Ownership.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     dirty:
       - <<: *quickClean
         crc: 0x788EADC4
@@ -1733,14 +1724,12 @@ plugins:
         itm: 3330
   ### OOO Other Options
   - name: 'OOO-Map_Markers_Stock.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     dirty:
       - <<: *quickClean
         crc: 0xA8FC19E3
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 43
   - name: 'OOO-Water_Weeds.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     dirty:
       - <<: *quickClean
         crc: 0x5FD2D492
@@ -1748,25 +1737,21 @@ plugins:
         itm: 1
   ### OOO Add-ons for Full version Only
   - name: 'OOO-DLT_Remover.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     clean:
       - crc: 0xC4D121FF
         util: 'TES4Edit v4.0.2i'
   ### OOO Add-ons for lite version Only
   - name: 'OOO-Armor_Perks_WearRate_Repair.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     clean:
       - crc: 0x09CB6B84
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Birthsigns.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     clean:
       - crc: 0xE0BB5D6C
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Combat_Skills_Perks_Marksmanship.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     dirty:
       - <<: *quickClean
@@ -1774,7 +1759,6 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 2
   - name: 'OOO-DaedraLord_Quests.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     dirty:
       - <<: *quickClean
@@ -1782,7 +1766,6 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 2
   - name: 'OOO-Dangerous_traps.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     dirty:
       - <<: *quickClean
@@ -1790,13 +1773,11 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 2
   - name: 'OOO-Deadly_Combat.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     clean:
       - crc: 0x8B51CA66
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-DLT_Immersion.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     dirty:
       - <<: *quickClean
@@ -1804,7 +1785,6 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 1
   - name: 'OOO-Magic_Effects+Enchantments.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     dirty:
       - <<: *quickClean
@@ -1812,7 +1792,6 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 1
   - name: 'OOO-Magic_Effects+Spells.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     dirty:
       - <<: *quickClean
@@ -1820,7 +1799,6 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 2
   - name: 'OOO-Magic_Game_Settings.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     dirty:
       - <<: *quickClean
@@ -1828,7 +1806,6 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 1
   - name: 'OOO-Potions.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     dirty:
       - <<: *quickClean
@@ -1836,7 +1813,6 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 15
   - name: 'OOO-ThiefGuild_Difficult.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
     clean:
       - crc: 0xDDBB8479

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1867,6 +1867,11 @@ plugins:
       - 'OOOAddonUndead.esp'
       - 'OOOAddonWilderness.esp'
       - 'OOODangerousDaedra.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0xD9A4F3B2
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 2
   ### OOO Equipment Add-on ###
   - name: 'OOOEquipmentAddon.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46028/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1684,23 +1684,23 @@ plugins:
       - crc: 0xD25FFD1E
         util: 'TES4Edit v4.0.2i'
   ### OOO Respawn Rate Options
+  - name: 'OOO-Respawn_(Month|Two_Week|Week|Year)\.esp'
+    msg:
+      - <<: *useBashTweakInstead
+        subs: [ 'Tweak Settings: World Cell Respawn Time' ]
   - name: 'OOO-Respawn_Month.esp'
-    msg: [ *bashedPatchTweak ]
     clean:
       - crc: 0xB57F7C18
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Two_Week.esp'
-    msg: [ *bashedPatchTweak ]
     clean:
       - crc: 0xF6344872
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Week.esp'
-    msg: [ *bashedPatchTweak ]
     clean:
       - crc: 0xB4241C0D
         util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Year.esp'
-    msg: [ *bashedPatchTweak ]
     clean:
       - crc: 0x9EF9532F
         util: 'TES4Edit v4.0.2i'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1842,6 +1842,10 @@ plugins:
       - 'OOOAddonUndead.esp'
       - 'OOOAddonWilderness.esp'
       - 'OOODangerousDaedra.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ 'OOOExtended.esp' ]
+        condition: 'active("OOOExtended.esp")'
     dirty:
       - <<: *quickClean
         crc: 0xD9A4F3B2
@@ -1850,6 +1854,10 @@ plugins:
   ### OOO Equipment Add-on ###
   - name: 'OOOEquipmentAddon.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46028/' ]
+    msg:
+      - <<: *alreadyInX
+        subs: [ 'OOOExtended.esp' ]
+        condition: 'active("OOOExtended.esp")'
     dirty:
       - <<: *quickClean
         crc: 0xCBB473A5

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1849,9 +1849,17 @@ plugins:
       - type: say
         content: 'Disable the "R.Head" Bash Tag from OOOShiveringIsles.esp to avoid conflicts with Oblivion Character Overhaul.'
         condition: 'file("Oblivion_Character_Overhaul.esp")'
+    dirty:
+      - <<: *quickClean
+        crc: 0xB82FC0B0
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 55
   - name: 'OOOSIArcheryPatch.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46508/' ]
     tag: [ NoMerge ]
+    clean:
+      - crc: 0xC52A442B
+        util: 'TES4Edit v4.0.2i'
   ### OOO Creature Add-ons ###
   - name: 'OOOCreatureAddons.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/45380/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1838,10 +1838,6 @@ plugins:
   ### OOO Creature Add-ons ###
   - name: 'OOOCreatureAddons.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/45380/' ]
-    inc:
-      - 'OOOAddonUndead.esp'
-      - 'OOOAddonWilderness.esp'
-      - 'OOODangerousDaedra.esp'
     msg:
       - <<: *alreadyInX
         subs: [ 'OOOExtended.esp' ]
@@ -1851,6 +1847,16 @@ plugins:
         crc: 0xD9A4F3B2
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 2
+  - name: 'OOO(AddonUndead|OOOAddonWilderness|OOODangerousDaedra)\.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/45380/' ]
+    msg:
+      - <<: *alreadyInX
+        subs: [ 'OOOCreatureAddons.esp' ]
+        condition: 'active("OOOCreatureAddons.esp")'
+      - <<: *alreadyInX
+        subs: [ 'OOOExtended.esp' ]
+        condition: 'active("OOOExtended.esp")'
+
   ### OOO Equipment Add-on ###
   - name: 'OOOEquipmentAddon.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46028/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1668,6 +1668,9 @@ plugins:
     msg:
       - <<: *useBashTweakInstead
         subs: [ 'Tweak Settings: World Cell Respawn Time' ]
+      - <<: *useOnlyOneX
+        subs: [ 'OOO Respawn Rate Options esp' ]
+        condition: 'many("OOO-Respawn_(Month|Two_Week|Week|Year)\.esp")'
   - name: 'OOO-Respawn_Month.esp'
     clean:
       - crc: 0xB57F7C18

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1821,9 +1821,8 @@ plugins:
   ### OOO Shivering Isles ###
   - name: 'OOOShiveringIsles.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46508/' ]
-    msg:
-      - type: say
-        content: 'Disable the "R.Head" Bash Tag from OOOShiveringIsles.esp to avoid conflicts with Oblivion Character Overhaul.'
+    tag:
+      - name: -R.Head
         condition: 'file("Oblivion_Character_Overhaul.esp")'
     dirty:
       - <<: *quickClean

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1646,6 +1646,11 @@ plugins:
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 2
   ### OOO Level Rate Options
+  - name: 'OOO-Level_(Normal|Slow|Stock)\.esp'
+    msg:
+      - <<: *useOnlyOneX
+        subs: [ 'OOO Level Rate Options esp' ]
+        condition: 'many("OOO-Level_(Normal|Slow|Stock)\.esp")'
   - name: 'OOO-Level_Normal.esp'
     clean:
       - crc: 0x295CB490

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1876,9 +1876,10 @@ plugins:
   - name: 'OOOEquipmentAddon.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46028/' ]
     dirty:
-      - crc: 0xb951292d
-        <<: *dirtyPlugin
-        itm: 1
+      - <<: *quickClean
+        crc: 0xCBB473A5
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 3
 
   ### OOO 3rd Party Patches and Addons ###
   - name: 'Better Hunting for OOO.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1621,7 +1621,6 @@ plugins:
 ### (OOO) Oscuro's Oblivion Overhaul ###
   - name: 'Oscuro''s_Oblivion_Overhaul.esm'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *doNotClean ]
     tag:
       - Actors.Spells
       - Graphics
@@ -1631,6 +1630,9 @@ plugins:
       - Stats
       - name: -Relations
         condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
+    clean:
+      - crc: 0x82322ED1
+        util: 'TES4Edit v4.0.2i'
   - name: 'Oscuro''s_Oblivion_Overhaul.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     after: [ 'Oblivion WarCry EV.esp' ]
@@ -1662,62 +1664,183 @@ plugins:
       - type: error
         content: 'Use "FCOM_Knights.esp" instead.'
         condition: *FCOMCond
+    dirty:
+      - <<: *quickClean
+        crc: 0x2D3B8E8F
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 2
+  ### OOO Level Rate Options
+  - name: 'OOO-Level_Normal.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    clean:
+      - crc: 0x295CB490
+        util: 'TES4Edit v4.0.2i'
+  - name: 'OOO-Level_Slow.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    clean:
+      - crc: 0x2D0F52CE
+        util: 'TES4Edit v4.0.2i'
+  - name: 'OOO-Level_Stock.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    clean:
+      - crc: 0xD25FFD1E
+        util: 'TES4Edit v4.0.2i'
   ### OOO Respawn Rate Options
   - name: 'OOO-Respawn_Month.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *bashedPatchTweak ]
+    clean:
+      - crc: 0xB57F7C18
+        util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Two_Week.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *bashedPatchTweak ]
+    clean:
+      - crc: 0xF6344872
+        util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Week.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *bashedPatchTweak ]
+    clean:
+      - crc: 0xB4241C0D
+        util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Respawn_Year.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *bashedPatchTweak ]
+    clean:
+      - crc: 0x9EF9532F
+        util: 'TES4Edit v4.0.2i'
   ### OOO Compatibility Options
+  - name: 'OOO-Container_Trap_Instant_Effects.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    clean:
+      - crc: 0x1560A30A
+        util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Magic_Script_Effect_Fix.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     tag:
       - Graphics
       - Sound
+    clean:
+      - crc: 0x7AD033AE
+        util: 'TES4Edit v4.0.2i'
+  - name: 'OOO-No_Guild_Ownership.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    dirty:
+      - <<: *quickClean
+        crc: 0x788EADC4
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 3330
+  ### OOO Other Options
+  - name: 'OOO-Map_Markers_Stock.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xA8FC19E3
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 43
+  - name: 'OOO-Water_Weeds.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    dirty:
+      - <<: *quickClean
+        crc: 0x5FD2D492
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 1
+  ### OOO Add-ons for Full version Only
+  - name: 'OOO-DLT_Remover.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    clean:
+      - crc: 0xC4D121FF
+        util: 'TES4Edit v4.0.2i'
   ### OOO Add-ons for lite version Only
   - name: 'OOO-Armor_Perks_WearRate_Repair.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    clean:
+      - crc: 0x09CB6B84
+        util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Birthsigns.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    clean:
+      - crc: 0xE0BB5D6C
+        util: 'TES4Edit v4.0.2i'
   - name: 'OOO-Combat_Skills_Perks_Marksmanship.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xA72465BC
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 2
   - name: 'OOO-DaedraLord_Quests.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    dirty:
+      - <<: *quickClean
+        crc: 0x4088F6EB
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 2
   - name: 'OOO-Dangerous_traps.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xEBBF4F85
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 2
   - name: 'OOO-Deadly_Combat.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    clean:
+      - crc: 0x8B51CA66
+        util: 'TES4Edit v4.0.2i'
   - name: 'OOO-DLT_Immersion.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    dirty:
+      - <<: *quickClean
+        crc: 0x5B6F42F5
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 1
   - name: 'OOO-Magic_Effects+Enchantments.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    dirty:
+      - <<: *quickClean
+        crc: 0x6A5D183A
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 1
   - name: 'OOO-Magic_Effects+Spells.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xBFE98741
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 2
   - name: 'OOO-Magic_Game_Settings.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xDC4B4EDF
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 1
   - name: 'OOO-Potions.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    dirty:
+      - <<: *quickClean
+        crc: 0x7AAE9B27
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 15
   - name: 'OOO-ThiefGuild_Difficult.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *alreadyInOOOFull ]
+    clean:
+      - crc: 0xDDBB8479
+        util: 'TES4Edit v4.0.2i'
 
   ### OOO Shivering Isles ###
   - name: 'OOOShiveringIsles.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1617,6 +1617,8 @@ plugins:
     url: [ 'https://www.nexusmods.com/oblivion/mods/5075/' ]
     inc:
       - 'Oscuro''s_Oblivion_Overhaul.esm'
+
+### (OOO) Oscuro's Oblivion Overhaul ###
   - name: 'Oscuro''s_Oblivion_Overhaul.esm'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
     msg: [ *doNotClean ]
@@ -1629,7 +1631,129 @@ plugins:
       - Stats
       - name: -Relations
         condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
+  - name: 'Oscuro''s_Oblivion_Overhaul.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    after: [ 'Oblivion WarCry EV.esp' ]
+    msg: [ *doNotClean ]
+    tag:
+      - Actors.ACBS
+      - Actors.AIData
+      - Actors.AIPackages
+      - Actors.CombatStyle
+      - Actors.Spells
+      - Actors.Stats
+      - Delev
+      - Factions
+      - Graphics
+      - Invent
+      - Names
+      - R.ChangeSpells
+      - Relations
+      - Relev
+      - Scripts
+      - Stats
+      - name: -Factions
+        condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
+      - name: -Relations
+        condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
+  - name: 'Oscuro''s_Oblivion_Overhaul - Knights of Nine.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg:
+      - type: error
+        content: 'Use "FCOM_Knights.esp" instead.'
+        condition: *FCOMCond
+  ### OOO Respawn Rate Options
+  - name: 'OOO-Respawn_Month.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *bashedPatchTweak ]
+  - name: 'OOO-Respawn_Two_Week.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *bashedPatchTweak ]
+  - name: 'OOO-Respawn_Week.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *bashedPatchTweak ]
+  - name: 'OOO-Respawn_Year.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *bashedPatchTweak ]
+  ### OOO Compatibility Options
+  - name: 'OOO-Magic_Script_Effect_Fix.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    tag:
+      - Graphics
+      - Sound
+  ### OOO Add-ons for lite version Only
+  - name: 'OOO-Armor_Perks_WearRate_Repair.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-Birthsigns.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-Combat_Skills_Perks_Marksmanship.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-DaedraLord_Quests.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-Dangerous_traps.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-Deadly_Combat.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-DLT_Immersion.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-Magic_Effects+Enchantments.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-Magic_Effects+Spells.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-Magic_Game_Settings.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-Potions.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
+  - name: 'OOO-ThiefGuild_Difficult.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
+    msg: [ *alreadyInOOOFull ]
 
+  ### OOO Shivering Isles ###
+  - name: 'OOOShiveringIsles.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46508/' ]
+    msg:
+      - type: say
+        content: 'Disable the "R.Head" Bash Tag from OOOShiveringIsles.esp to avoid conflicts with Oblivion Character Overhaul.'
+        condition: 'file("Oblivion_Character_Overhaul.esp")'
+  - name: 'OOOSIArcheryPatch.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46508/' ]
+    tag: [ NoMerge ]
+  ### OOO Creature Add-ons ###
+  - name: 'OOOCreatureAddons.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/45380/' ]
+    inc:
+      - 'OOOAddonUndead.esp'
+      - 'OOOAddonWilderness.esp'
+      - 'OOODangerousDaedra.esp'
+  ### OOO Equipment Add-on ###
+  - name: 'OOOEquipmentAddon.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/46028/' ]
+    dirty:
+      - crc: 0xb951292d
+        <<: *dirtyPlugin
+        itm: 1
+
+  ### OOO 3rd Party Patches and Addons ###
+  - name: 'Better Hunting for OOO.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/35223' ]
+    tag: [ Stats ]
+  - name: 'OOO-Better_Priced_Clutter.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/29012' ]
+    tag: [ Stats ]
+  - name: 'Geomancy & Gem Dust OOO (No Spell Change).esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/21102' ]
+    inc: [ 'Geomancy & Gem Dust OOO.esp' ]
 
 # (MMM) Martigen’s Monster Mod
   - name: 'Mart''s Monster Mod.*\.es(m|p)'
@@ -6287,71 +6411,6 @@ plugins:
     inc:
       - 'FCOM_WarCry.esp'
     tag: [ Stats ]
-  - name: 'Oscuro''s_Oblivion_Overhaul.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    after: [ 'Oblivion WarCry EV.esp' ]
-    msg: [ *doNotClean ]
-    tag:
-      - Actors.ACBS
-      - Actors.AIData
-      - Actors.AIPackages
-      - Actors.CombatStyle
-      - Actors.Spells
-      - Actors.Stats
-      - Delev
-      - Factions
-      - Graphics
-      - Invent
-      - Names
-      - R.ChangeSpells
-      - Relations
-      - Relev
-      - Scripts
-      - Stats
-      - name: -Factions
-        condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
-      - name: -Relations
-        condition: 'file("Mart''s Monster Mod for OOO.esm") or file("FCOM_Convergence.esm")'
-  - name: 'OOO-Armor_Perks_WearRate_Repair.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Birthsigns.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Combat_Skills_Perks_Marksmanship.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-DaedricLord_Quests.esp'
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-DaedraLord_Quests.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Dangerous_traps.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Deadly_Combat.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-DLT_Immersion.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Magic_Effects+Enchantments.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Magic_Effects+Spells.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Magic_Game_Settings.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Potions.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-Thief_Guild_Difficult.esp'
-    msg: [ *alreadyInOOOFull ]
-  - name: 'OOO-ThiefGuild_Difficult.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *alreadyInOOOFull ]
   - name: 'OOO-Ayleid Coin Add-on.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/10671' ]
     msg: [ *obsolete ]
@@ -6545,23 +6604,6 @@ plugins:
     tag: [ Invent ]
   - name: 'mg19obsefix.esp'
     req: [ *OBSE ]
-  - name: 'OOO-Better_Priced_Clutter.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/29633/' ]
-    tag: [ Stats ]
-  - name: 'OOOCreatureAddons.esp'
-    url:
-      - 'https://www.nexusmods.com/oblivion/mods/45380/'
-      - 'https://www.nexusmods.com/oblivion/mods/46199/'
-    inc:
-      - 'OOOAddonUndead.esp'
-      - 'OOOAddonWilderness.esp'
-      - 'OOODangerousDaedra.esp'
-  - name: 'OOOEquipmentAddon.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46028/' ]
-    dirty:
-      - crc: 0xb951292d
-        <<: *dirtyPlugin
-        itm: 1
   - name: 'RealitySpectreStars2HeavenBetterPotionsOOOEffects.esp'
     tag: [ Graphics ]
   - name: 'AGEHA Tortured Souls OOO.esp'
@@ -6589,9 +6631,6 @@ plugins:
     inc:
       - 'ArmamentariumLL4OOO.esp'
       - 'ArmamentariumLLVendors.esp'
-  - name: 'Better Hunting for OOO.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/35223' ]
-    tag: [ Stats ]
   - name: 'FCOM_Cobl.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/12249/' ]
     msg:
@@ -7243,9 +7282,6 @@ plugins:
       - C.Owner
       - Names
       - Relations
-  - name: 'Geomancy & Gem Dust OOO (No Spell Change).esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/21102' ]
-    inc: [ 'Geomancy & Gem Dust OOO.esp' ]
   - name: 'EVE_StockEquipmentReplacer4FCOM.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/24078/' ]
     msg:
@@ -11435,12 +11471,6 @@ plugins:
     tag:
       - Graphics
       - NoMerge
-  - name: 'Oscuro''s_Oblivion_Overhaul - Knights of Nine.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg:
-      - type: error
-        content: 'Use "FCOM_Knights.esp" instead.'
-        condition: *FCOMCond
   - name: 'Dragon Templar.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/31961' ]
     msg:
@@ -18814,15 +18844,6 @@ plugins:
         itm: 1
   - name: 'ZUSIO-SM Plugin Refurbish SI-patch.esp'
     tag: [ Scripts ]
-  - name: 'OOOShiveringIsles.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46508/' ]
-    msg:
-      - type: say
-        content: 'Disable the "R.Head" Bash Tag from OOOShiveringIsles.esp to avoid conflicts with Oblivion Character Overhaul.'
-        condition: 'file("Oblivion_Character_Overhaul.esp")'
-  - name: 'OOOSIArcheryPatch.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46508/' ]
-    tag: [ NoMerge ]
   - name: 'bgMagic(D|E)V.esp'
     msg: [ *doNotClean ]
     tag:
@@ -19256,9 +19277,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/oblivion/mods/27720' ]
     after:
       - 'Oscuro''s_Oblivion_Overhaul.esp'
-  - name: 'OOO-Respawn_(Year|Month|(Two_)?Week)\.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    msg: [ *bashedPatchTweak ]
   - name: 'Z 1 Hour respawn.esp'
     msg: [ *bashedPatchTweak ]
   - name: 'ThingasTime 1-15 Scale.esp'
@@ -19507,11 +19525,6 @@ plugins:
     tag:
       - Graphics
       - Names
-      - Sound
-  - name: 'OOO-Magic_Script_Effect_Fix.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/46199/' ]
-    tag:
-      - Graphics
       - Sound
   - name: 'NoScriptHitVisual.esp'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1880,6 +1880,19 @@ plugins:
         crc: 0xCBB473A5
         util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 3
+  ### OOO Extended ###
+  - name: 'OOOExtended.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/47177/' ]
+    dirty:
+      - <<: *quickClean
+        crc: 0x7E3B1AE5
+        util: '[TES4Edit v4.0.2i](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 4
+  - name: 'OOOExtendedArcheryPatch.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/47177/' ]
+    clean:
+      - crc: 0xDB360623
+        util: 'TES4Edit v4.0.2i'
 
   ### OOO 3rd Party Patches and Addons ###
   - name: 'Better Hunting for OOO.esp'


### PR DESCRIPTION
As part of #2 

Add cleaning info:
[OOO - Updated](https://www.nexusmods.com/oblivion/mods/46199)
[Creature Add-ons for OOO](https://www.nexusmods.com/oblivion/mods/45380/?)
[Equipment Add-on for OOO](https://www.nexusmods.com/oblivion/mods/46028/?)
[OOO Extended](https://www.nexusmods.com/oblivion/mods/47177)
[OOO Shivering Isles](https://www.nexusmods.com/oblivion/mods/46508)

Placed OOO plugins together for easier maintenance.
Combined location metadata for OOO.
Update tag suggestions
- Tags are already included in header description.

Replace messages:
- bashedPatchTweak with useBashTweakInstead.
- Remove tag message with conditional tag.

Add already in X messages:

Mods included in OOOExtended.
  - OOOEquipmentAddon.esp
  - OOOCreatureAddons.esp

Mods included in OOOCreatureAddons.
  - OOOAddonUndead.esp
  - OOOAddonWilderness.esp
  - OOODangerousDaedra.esp

Replaced use instead message for OOO Knights.
- Added inc for FCOM_Convergence.esm.

Add use only one messages:
- OOO Level Rate Options.
- OOO Respawn Rate Options.