### PR TITLE
Update Cats and Rats

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3923,8 +3923,8 @@ plugins:
   - name: 'Open Cities + Cats & Rats( for Francescos| for MMM)?\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
     msg:
-      - type: say
-        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
+      - <<: *obsolete
+        subs: [ '[Cats and Rats 2.5b](http://theelderscrolls.info/?go=dlfile&fileid=255)' ]
   - name: 'zCats & Rats.esp'
     url: [ 'http://theelderscrolls.info/?go=dlfile&fileid=255' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3929,17 +3929,7 @@ plugins:
     msg:
       - type: say
         content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
-  - name: 'Open Cities + Cats & Rats.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
-  - name: 'Open Cities + Cats & Rats for MMM.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
-  - name: 'Open Cities + Cats & Rats for Francescos.esp'
+  - name: 'Open Cities + Cats & Rats( for Francescos| for MMM)?\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
     msg:
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3913,18 +3913,17 @@ plugins:
       - Graphics
       - NoMerge
 
-  - name: '(z)?Cats & Rats( for Francescos| for MMM)?\.esp'
+  - name: '(Open Cities + )?Cats & Rats( for Francescos| for MMM)?\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
+    msg:
+      - <<: *obsolete
+        subs: [ '[Cats and Rats 2.5b](http://theelderscrolls.info/?go=dlfile&fileid=255)' ]
+  - name: '(z)?Cats & Rats( for Francescos| for MMM)?\.esp'
     msg:
       - type: say
         content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
   - name: 'Cats & Rats.esp'
     tag: [ Scripts ]
-  - name: 'Open Cities + Cats & Rats( for Francescos| for MMM)?\.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - <<: *obsolete
-        subs: [ '[Cats and Rats 2.5b](http://theelderscrolls.info/?go=dlfile&fileid=255)' ]
   - name: 'zCats & Rats.esp'
     url: [ 'http://theelderscrolls.info/?go=dlfile&fileid=255' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3913,7 +3913,7 @@ plugins:
       - Graphics
       - NoMerge
 
-  - name: 'Cats & Rats( for Francescos| for MMM)?\.esp'
+  - name: '(z)?Cats & Rats( for Francescos| for MMM)?\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
     msg:
       - type: say
@@ -3927,9 +3927,6 @@ plugins:
         subs: [ '[Cats and Rats 2.5b](http://theelderscrolls.info/?go=dlfile&fileid=255)' ]
   - name: 'zCats & Rats.esp'
     url: [ 'http://theelderscrolls.info/?go=dlfile&fileid=255' ]
-    msg:
-      - type: say
-        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
     dirty:
       - <<: *quickClean
         crc: 0x99F45386

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3918,6 +3918,16 @@ plugins:
       - type: say
         content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
     tag: [ Scripts ]
+  - name: 'zCats & Rats.esp'
+    url: [ 'http://theelderscrolls.info/?go=dlfile&fileid=255' ]
+    msg:
+      - type: say
+        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
+    dirty:
+      - <<: *quickClean
+        crc: 0x99F45386
+        util: '[TES4Edit v4.0.3](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 14
   - name: 'EnableFreeLookNoWheel.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/9499' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3912,6 +3912,7 @@ plugins:
     tag:
       - Graphics
       - NoMerge
+
   - name: 'Cats & Rats.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
     msg:
@@ -3953,6 +3954,7 @@ plugins:
         crc: 0x99F45386
         util: '[TES4Edit v4.0.3](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 14
+
   - name: 'EnableFreeLookNoWheel.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/9499' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3918,6 +3918,31 @@ plugins:
       - type: say
         content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
     tag: [ Scripts ]
+  - name: 'Cats & Rats for MMM.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
+    msg:
+      - type: say
+        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
+  - name: 'Cats & Rats for Francescos.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
+    msg:
+      - type: say
+        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
+  - name: 'Open Cities + Cats & Rats.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
+    msg:
+      - type: say
+        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
+  - name: 'Open Cities + Cats & Rats for MMM.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
+    msg:
+      - type: say
+        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
+  - name: 'Open Cities + Cats & Rats for Francescos.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
+    msg:
+      - type: say
+        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
   - name: 'zCats & Rats.esp'
     url: [ 'http://theelderscrolls.info/?go=dlfile&fileid=255' ]
     msg:
@@ -7258,16 +7283,6 @@ plugins:
     msg:
       - type: say
         content: 'Use the "Set LapMinLock to 0" console command instead.'
-  - name: 'Cats & Rats for MMM.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
-  - name: 'Cats & Rats for Francescos.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
   - name: 'TGND2 OOO Replacer.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/41928' ]
     tag:
@@ -12904,21 +12919,6 @@ plugins:
     inc: [ 'xulCheydinhalFalls.esp' ]
   - name: 'Open Cities.esp'
     msg: [ *obsolete ]
-  - name: 'Open Cities + Cats & Rats.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
-  - name: 'Open Cities + Cats & Rats for MMM.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
-  - name: 'Open Cities + Cats & Rats for Francescos.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Obsolete. Please update Cats&Rats and Open Cities to latest versions.'
   - name: 'Open Cities New Sheoth.esp'
     url:
       - 'https://www.nexusmods.com/oblivion/mods/16360'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3913,22 +3913,13 @@ plugins:
       - Graphics
       - NoMerge
 
+  - name: 'Cats & Rats( for Francescos| for MMM)?\.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
+    msg:
+      - type: say
+        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
   - name: 'Cats & Rats.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
     tag: [ Scripts ]
-  - name: 'Cats & Rats for MMM.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
-  - name: 'Cats & Rats for Francescos.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
-    msg:
-      - type: say
-        content: 'Conflicts slightly with Harvest Containers; some in city containers will not play HC anims while this mod is active.'
   - name: 'Open Cities + Cats & Rats( for Francescos| for MMM)?\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/5276' ]
     msg:


### PR DESCRIPTION
Restored updated version `zCats & Rats.esp`.
[Cats and Rats EV](http://theelderscrolls.info/?go=dlfile&fileid=255).
Combine shared metadata.
Added obsolete mesage with a link to the new version to the [old versions](https://www.nexusmods.com/oblivion/mods/5276) plugins.
Updated cleaning info.
Version: 2.5b