### PR TITLE
Replace Balanced Magic cleaning info with doNotClean message

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18996,17 +18996,7 @@ plugins:
 
   - name: 'BalancedMagic.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/45249' ]
-    dirty:
-      # version: 2.5
-      - <<: *quickClean
-        crc: 0x0D32E9EA
-        util: '[TES4Edit v4.0.1](https://www.nexusmods.com/oblivion/mods/11536)'
-        itm: 3
-      # version: 2.5, Esp without nature Summons
-      - <<: *quickClean
-        crc: 0xCEF52118
-        util: '[TES4Edit v4.0.1](https://www.nexusmods.com/oblivion/mods/11536)'
-        itm: 2
+    msg: [ *doNotClean ]
 
   - name: 'BMEnchantmentRebalance.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/45249' ]


### PR DESCRIPTION
Quote from mods [description](https://www.nexusmods.com/oblivion/mods/45249).
> Any identical to master records are on purpose to override changes
> from OOO, Race Balancing Project or whatever you might be using
> that could interfer with my mod.