### PR TITLE
Sort Castle Seaview after UL Lost Coast

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1836,6 +1836,9 @@ plugins:
         name: 'Castle Seaview'
       - link: 'https://www.nexusmods.com/oblivion/mods/32594'
         name: 'Castle Seaview Friend or Foe'
+    after:
+      - 'Unique Landscapes.esp'
+      - 'xulBeachesOfCyrodiilLostCoast.esp'
     dirty:
       - <<: *quickClean
         crc: 0xAC0443CD


### PR DESCRIPTION
Suggested load order from UL patch readme.
Tested in xEdit and changes are still reverted by
UL Lost Coast even when a patch is used.