### PR TITLE
Sort Integration The Stranded Light after conflicting UL plugins

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1898,6 +1898,10 @@ plugins:
     after:
       - 'Open Cities Classic.esp'
       - 'Open Cities Reborn.esp'
+      - 'Unique Landscapes.esp'
+      - 'xulSilverfishRiverValley.esp'
+      - 'xulSnowdale.esp'
+      - 'xulTheEasternPeaks.esp'
     inc: [ 'bgIntegrationIntegratedEV.esp' ]
     req: [ 'DLCShiveringIsles.esp' ]
     msg: [ *doNotClean ]


### PR DESCRIPTION
Suggested load order from UL patch readme.
Tested in xEdit and changes are still reverted by
UL plugins even when a patch is used.