### PR TITLE
Fix regexes using invalid escape \p

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13401,136 +13401,136 @@ plugins:
         util: 'TES4Edit v4.0.3'
 
 ###### Unique Landscapes Compatibility Patches (ULE/ULM/ULS) ######
-  - name: 'UL(E|M|S) .*\patch.esp'
+  - name: 'UL(E|M|S) .*patch\.esp'
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/13834'
         name: 'Unique Landscapes Compatibility Patches'
-  - name: 'ULE .*\patch.esp'
+  - name: 'ULE .*patch\.esp'
     after:
       - name: 'Unique Landscapes.esp'
         condition: 'version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-AncientRedwoods patch.esp'
+  - name: 'ULE .*-AncientRedwoods patch\.esp'
     req:
       - name: 'xulAncientRedwoods.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-AncientYews patch.esp'
+  - name: 'ULE .*-AncientYews patch\.esp'
     req:
       - name: 'xulAncientYews.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-ArriusCreek patch.esp'
+  - name: 'ULE .*-ArriusCreek patch\.esp'
     req:
       - name: 'xulArriusCreek.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-AspenWood patch.esp'
+  - name: 'ULE .*-AspenWood patch\.esp'
     req:
       - name: 'xulAspenWood.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-LostCoast patch.esp'
+  - name: 'ULE .*-LostCoast patch\.esp'
     req:
       - name: 'xulBeachesOfCyrodiilLostCoast.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-BlackwoodForest patch.esp'
+  - name: 'ULE .*-BlackwoodForest patch\.esp'
     req:
       - name: 'xulBlackwoodForest.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-BravilBarrowfields patch.esp'
+  - name: 'ULE .*-BravilBarrowfields patch\.esp'
     req:
       - name: 'xulBravilBarrowfields.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-CheydinhalFalls patch.esp'
+  - name: 'ULE .*-CheydinhalFalls patch\.esp'
     req:
       - name: 'xulCheydinhalFalls.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-ChorrolHinterland patch.esp'
+  - name: 'ULE .*-ChorrolHinterland patch\.esp'
     req:
       - name: 'xulChorrolHinterland.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-CliffsOfAnvil patch.esp'
+  - name: 'ULE .*-CliffsOfAnvil patch\.esp'
     req:
       - name: 'xulCliffsOfAnvil.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-CloudtopMountains patch.esp'
+  - name: 'ULE .*-CloudtopMountains patch\.esp'
     req:
       - name: 'xulCloudtopMountains.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-ColovianHighlands patch.esp'
+  - name: 'ULE .*-ColovianHighlands patch\.esp'
     req:
       - name: 'xulColovianHighlands_EV.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-DarkForest patch.esp'
+  - name: 'ULE .*-DarkForest patch\.esp'
     req:
       - name: 'xuldarkforest.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-EasternPeaks patch.esp'
+  - name: 'ULE .*-EasternPeaks patch\.esp'
     req:
       - name: 'xulTheEasternPeaks.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-EntiusGorge patch.esp'
+  - name: 'ULE .*-EntiusGorge patch\.esp'
     req:
       - name: 'xulEntiusGorge.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-FallenleafEverglade patch.esp'
+  - name: 'ULE .*-FallenleafEverglade patch\.esp'
     req:
       - name: 'xulFallenleafEverglade.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-TheHeath patch.esp'
+  - name: 'ULE .*-TheHeath patch\.esp'
     req:
       - name: 'xulTheHeath.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-ImperialIsle patch.esp'
+  - name: 'ULE .*-ImperialIsle patch\.esp'
     req:
       - name: 'xulImperialIsle.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-JerallGlacier patch.esp'
+  - name: 'ULE .*-JerallGlacier patch\.esp'
     req:
       - name: 'xulJerallGlacier.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-LushWoodlands patch.esp'
+  - name: 'ULE .*-LushWoodlands patch\.esp'
     req:
       - name: 'xulLushWoodlands.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-PantherRiver patch.esp'
+  - name: 'ULE .*-PantherRiver patch\.esp'
     req:
       - name: 'xulPantherRiver.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-RiverEthe patch.esp'
+  - name: 'ULE .*-RiverEthe patch\.esp'
     req:
       - name: 'xulRiverEthe.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-RollingHills patch.esp'
+  - name: 'ULE .*-RollingHills patch\.esp'
     req:
       - name: 'xulRollingHills_EV.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-SilverfishRiverValley patch.esp'
+  - name: 'ULE .*-SilverfishRiverValley patch\.esp'
     req:
       - name: 'xulSilverfishRiverValley.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-SkingradOutskirts patch.esp'
+  - name: 'ULE .*-SkingradOutskirts patch\.esp'
     req:
       - name: 'xulSkingradOutskirts.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-Snowdale patch.esp'
+  - name: 'ULE .*-Snowdale patch\.esp'
     req:
       - name: 'xulSnowdale.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-StendarrValley patch.esp'
+  - name: 'ULE .*-StendarrValley patch\.esp'
     req:
       - name: 'xulStendarrValley.esp'
         condition: 'not version("Unique Landscapes.esp", "2.0.0", >=)'
-  - name: 'ULE .*\-xulPatch_AY_AC patch.esp'
+  - name: 'ULE .*-xulPatch_AY_AC patch\.esp'
     after: [ 'xulPatch_AY_AC.esp' ]
   # ULC Patches - AltStart Town Lindum #
-  - name: 'UL(M|S) Lindum.*\patch.esp'
+  - name: 'UL(M|S) Lindum.*patch\.esp'
     req:
       - name: 'AltVillageStart.esp'
         display: '[AltStart Town Lindum](https://www.nexusmods.com/oblivion/mods/44903)'
-  - name: 'UL(M|S) Lindum.*(BetterCitiesChorrol).*\patch.esp'
+  - name: 'UL(M|S) Lindum.*(BetterCitiesChorrol).*patch\.esp'
     req:
       - name: 'Better Cities CHORROL.esp'
         display: 'Better Cities Full or CHORROL'
         condition: 'not file("Better Cities Full.esp")'
   # ULC Patches - Amen'thalas Well House #
-  - name: 'UL(M|S) Amen''thalasWellHouse.*\patch.esp'
+  - name: 'UL(M|S) Amen''thalasWellHouse.*patch\.esp'
     req:
       - name: 'Amen''thalas Well House.esp'
         display: '[Amen''thalas Well House](https://www.nexusmods.com/oblivion/mods/32710)'
@@ -13545,24 +13545,24 @@ plugins:
       - name: 'Atah wizard home - eng.esp'
         display: '[Atahnoral: The Wizard''s Home](https://www.nexusmods.com/oblivion/mods/37356)'
   # ULC Patches - Better Cities #
-  - name: 'UL(E|M|S) .*(BetterCities).*\patch.esp'
+  - name: 'UL(E|M|S) .*(BetterCities).*patch\.esp'
     after: [ 'Better Cities Full.esp' ]
-  - name: 'UL(E|M|S) BetterCitiesBravil.*\patch.esp'
+  - name: 'UL(E|M|S) BetterCitiesBravil.*patch\.esp'
     req:
       - name: 'Better Cities BRAVIL.esp'
         display: 'Better Cities Full or BRAVIL'
         condition: 'not file("Better Cities Full.esp")'
-  - name: 'UL(E|M|S) BetterCitiesBruma.*\patch.esp'
+  - name: 'UL(E|M|S) BetterCitiesBruma.*patch\.esp'
     req:
       - name: 'Better Cities BRUMA.esp'
         display: 'Better Cities Full or BRUMA'
         condition: 'not file("Better Cities Full.esp")'
-  - name: 'UL(E|M|S) BetterCitiesCheydinhal.*\patch.esp'
+  - name: 'UL(E|M|S) BetterCitiesCheydinhal.*patch\.esp'
     req:
       - name: 'Better Cities CHEYDINHAL.esp'
         display: 'Better Cities Full or CHEYDINHAL'
         condition: 'not file("Better Cities Full.esp")'
-  - name: 'UL(E|M|S) BetterCitiesSkingrad.*\patch.esp'
+  - name: 'UL(E|M|S) BetterCitiesSkingrad.*patch\.esp'
     req:
       - name: 'Better Cities SKINGRAD.esp'
         display: 'Better Cities Full or SKINGRAD'
@@ -13574,29 +13574,29 @@ plugins:
         display: 'Better Cities Full or BRAVIL & BRUMA & CHEYDINHAL & SKINGRAD'
         condition: 'not file("Better Cities BRAVIL.esp") and not file("Better Cities BRUMA.esp") and not file("Better Cities CHEYDINHAL.esp") and not file("Better Cities SKINGRAD.esp")'
   # ULC Patches - Blood & Mud #
-  - name: 'ULE Blood&Mud.*\patch.esp'
+  - name: 'ULE Blood&Mud.*patch\.esp'
     req:
       - name: 'Blood&Mud.esp'
         display: '[Blood & Mud Dirt Deluxe Anglais](https://www.nexusmods.com/oblivion/mods/12016)'
   - name: 'ULE Blood&Mud-UniqueLandscapes merged patch.esp'
     after: [ 'xulCheydinhalFalls.esp' ]
   # ULC Patches - Castle Dracula #
-  - name: 'UL(M|S) CastleDracula-Snowdale patch.esp'
+  - name: 'UL(M|S) CastleDracula-Snowdale patch\.esp'
     req:
       - name: 'CV - Castle Dracula.esp'
         display: '[Castle Dracula](https://www.nexusmods.com/oblivion/mods/22384)'
   # ULC Patches - Castle Eltz #
-  - name: 'UL(M|S) CastleEltz-EasternPeaks patch.esp'
+  - name: 'UL(M|S) CastleEltz-EasternPeaks patch\.esp'
     req:
       - name: 'Castle Eltz.esp'
         display: '[Castle Eltz](https://www.nexusmods.com/oblivion/mods/32500)'
   # ULC Patches - Castle Seaview #
-  - name: 'UL(M|S) CastleSeaview-LostCoast patch.esp'
+  - name: 'UL(M|S) CastleSeaview-LostCoast patch\.esp'
     inc:
       - '(DC) Sutch Reborn.esp'
       - 'EaglesRest.esp'
   # ULC Patches - Chorrol Plateau #
-  - name: 'ULE ChorrolPlateau.*\patch.esp'
+  - name: 'ULE ChorrolPlateau.*patch\.esp'
     req:
       - name: 'ChorrolPlateau.esp'
         display: '[Chorrol Plateau](https://www.nexusmods.com/oblivion/mods/34726)'
@@ -13608,7 +13608,7 @@ plugins:
       - name: 'CountryHome.esp'
         display: '[Country Home](https://www.nexusmods.com/oblivion/mods/5939)'
   # ULC Patches - Daggerfall Memories: Cybiades #
-  - name: 'UL(M|S) Cybiades-LostCoast patch.esp'
+  - name: 'UL(M|S) Cybiades-LostCoast patch\.esp'
     req:
       - name: 'Cybiades.esp'
         display: '[Daggerfall Memories: Cybiades](https://www.nexusmods.com/oblivion/mods/11755)'
@@ -13618,7 +13618,7 @@ plugins:
       - name: '(DC) County Sutch - New Haven.esp'
         display: '[(Dragon Captions) County Sutch: New Haven City](https://www.nexusmods.com/oblivion/mods/32298)'
   # ULC Patches - (Dragon Captions) County Sutch: Owl's Cove #
-  - name: 'UL(M|S) CountySutchOwlsCove-LostCoast patch.esp'
+  - name: 'UL(M|S) CountySutchOwlsCove-LostCoast patch\.esp'
     req:
       - name: '(DC) County Sutch - Owls Cove.esp'
         display: '[(Dragon Captions) County Sutch: Owl''s Cove](https://www.nexusmods.com/oblivion/mods/35757)'
@@ -13627,30 +13627,30 @@ plugins:
     req:
       - name: '(DC) Sutch Reborn.esp'
         display: '[(Dragon Captions) The Imperial City of Sutch Reborn](https://www.nexusmods.com/oblivion/mods/16815)'
-  - name: 'UL(M|S) SutchReborn-LostCoast patch.esp'
+  - name: 'UL(M|S) SutchReborn-LostCoast patch\.esp'
     inc: [ 'Castle_Seaview.esp' ]
   # ULC Patches - Duke Patrick's Combat Archery #
-  - name: 'UL(M|S) DukePatricksSCACombatArchery-LostCoast patch.esp'
+  - name: 'UL(M|S) DukePatricksSCACombatArchery-LostCoast patch\.esp'
     req:
       - name: 'Duke Patricks - Combat Archery.esp'
         display: '[Duke Patrick''s Combat Archery](http://tesalliance.org/forums/index.php?/files/file/514-duke-patricks-combat-archery/)'
   # ULC Patches - Duke Patrick's Fortress Of FeaR #
-  - name: 'UL(M|S) DukePatricksFortressOfFear-Snowdale patch.esp'
+  - name: 'UL(M|S) DukePatricksFortressOfFear-Snowdale patch\.esp'
     req:
       - name: 'Duke Patricks - Fortress of Fear.esp'
         display: '[Duke Patrick''s Fortress Of FeaR](http://tesalliance.org/forums/index.php?/files/file/780-duke-patricks-combat-magic-ii-duke-patricks-incursion-into-fortress-of-fear/)'
   # ULC Patches - Eagle's Rest #
-  - name: 'UL(M|S) EaglesRest-LostCoast patch.esp'
+  - name: 'UL(M|S) EaglesRest-LostCoast patch\.esp'
     req:
       - name: 'EaglesRest.esp'
         display: '[Eagle''s Rest](http://tesalliance.org/forums/index.php?/files/file/426-eagles-rest-v10/)'
   # ULC Patches - Eastbrink Town #
-  - name: 'UL(M|S) Eastbrink-SilverfishRiverValley patch.esp'
+  - name: 'UL(M|S) Eastbrink-SilverfishRiverValley patch\.esp'
     inc: [ 'ImpeREAL Empire - Unique Forts.esp' ]
     req:
       - name: 'EastbrinkBasic.esp'
         display: '[Eastbrink Town](https://www.nexusmods.com/oblivion/mods/36619)'
-  - name: 'UL(M|S) Eastbrink-ImpeREALForts-SilverfishRiverValley patch.esp'
+  - name: 'UL(M|S) Eastbrink-ImpeREALForts-SilverfishRiverValley patch\.esp'
     inc: [ 'The Lost Spires.esp' ]
   # ULC Patches - Elsweyr the Deserts of Anequina #
   - name: 'ULE Anequina-FallenleafEverglade patch.esp'
@@ -13658,41 +13658,41 @@ plugins:
       - name: 'ElsweyrAnequina.esp'
         display: '[Elsweyr the Deserts of Anequina](https://www.nexusmods.com/oblivion/mods/25023)'
   # ULC Patches - English Billsburg #
-  - name: 'ULE Billsburg-.*\patch.esp'
+  - name: 'ULE Billsburg-.*patch\.esp'
     req:
       - name: 'English Billsburg_Rens_Hair.esp'
         display: '[English Billsburg with Rens Hair](https://www.nexusmods.com/oblivion/mods/23079)'
   - name: 'ULE Billsburg-UniqueLandscapes merged patch.esp'
     after: [ 'xulCloudtopMountains.esp' ]
   # ULC Patches - Et in Arkay Ego #
-  - name: 'UL(E|M|S) EtInArkay-.*\patch.esp'
+  - name: 'UL(E|M|S) EtInArkay-.*patch\.esp'
     req:
       - name: 'EiAmod.esp'
         display: '[Et in Arkay Ego](https://www.nexusmods.com/oblivion/mods/21816)'
   # ULC Patches - Fighters Guild Quests #
-  - name: 'ULE FightersGuildQuests.*\patch.esp'
+  - name: 'ULE FightersGuildQuests.*patch\.esp'
     req:
       - name: 'Fighters Guild Quests.esp'
         display: '[Fighters Guild Quests](https://www.nexusmods.com/oblivion/mods/41012)'
   - name: 'ULE FightersGuildQuests-SnowyRoad-ULCombo Patch.esp'
     after: [ 'xulJerallGlacier.esp' ]
   # ULC Patches - Frostcrag Reborn De-Isolated #
-  - name: 'UL(M|S) FrostcragReborn-Snowdale patch.esp'
+  - name: 'UL(M|S) FrostcragReborn-Snowdale patch\.esp'
     req:
       - name: 'DLCFrostcragReborn.esp'
         display: '[Frostcrag Reborn De-Isolated](https://www.nexusmods.com/oblivion/mods/40752/)'
         condition: 'not version("DLCfrostcrag.esp", "3.0", >=)'
   # ULC Patches - Fuse's Snail Racing #
-  - name: 'UL(M|S) FuseSnailRacing-ImperialIsle patch.esp'
+  - name: 'UL(M|S) FuseSnailRacing-ImperialIsle patch\.esp'
     req:
       - name: 'FuseSnailRacing.esp'
         display: '[Fuse''s Snail Racing](https://www.nexusmods.com/oblivion/mods/4596)'
   # ULC Patches - GATES TO AESGAARD #
-  - name: 'UL(M|S) GatesToAesgaardEp1-JerallGlacier patch.esp'
+  - name: 'UL(M|S) GatesToAesgaardEp1-JerallGlacier patch\.esp'
     req:
       - name: 'GTAesgaard.esp'
         display: '[GATES TO AESGAARD - Episode One](https://www.nexusmods.com/oblivion/mods/13814)'
-  - name: 'UL(M|S) GatesToAesgaardEp2-Snowdale patch.esp'
+  - name: 'UL(M|S) GatesToAesgaardEp2-Snowdale patch\.esp'
     req:
       - name: 'GTAesgaard_2.esp'
         display: '[GATES TO AESGAARD - Episode Two](https://www.nexusmods.com/oblivion/mods/21693)'
@@ -13702,34 +13702,34 @@ plugins:
       - name: 'Gift of Kynareth.esp'
         display: '[Gift Of Kynareth](https://www.nexusmods.com/oblivion/mods/7825)'
   # ULC Patches - Goblinwatch Keep #
-  - name: 'UL(E|M|S) GoblinwatchKeep.*\patch.esp'
+  - name: 'UL(E|M|S) GoblinwatchKeep.*patch\.esp'
     req:
       - name: 'GoblinwatchKeep.esp'
         display: '[Goblinwatch Keep](https://www.nexusmods.com/oblivion/mods/5807)'
   # ULC Patches - Hammerfell: The Eastern Grasslands #
-  - name: 'UL(M|S) Hammerfell-ColovianHighlands patch.esp'
+  - name: 'UL(M|S) Hammerfell-ColovianHighlands patch\.esp'
     req:
       - name: 'HammerfellBorders.esp'
         display: '[Hammerfell: The Eastern Grasslands](https://www.nexusmods.com/oblivion/mods/34484)'
   # ULC Patches - Hentai's Lovely House #
-  - name: 'UL(M|S) HentaiLovelyHouse2-AncientYews patch.esp'
+  - name: 'UL(M|S) HentaiLovelyHouse2-AncientYews patch\.esp'
     req:
       - name: 'HentaiLovelyHouse.esp'
         display: '[Hentai''s Lovely House](https://www.nexusmods.com/oblivion/mods/36673)'
   # ULC Patches - HENTAI MANIA 2 #
-  - name: 'UL(M|S) HentaiMania2-LostCoast patch.esp'
+  - name: 'UL(M|S) HentaiMania2-LostCoast patch\.esp'
     req:
       - name: 'HentaiMania2.esp'
         display: '[HENTAI MANIA 2](https://www.nexusmods.com/oblivion/mods/34179)'
   # ULC Patches - Hoarfrost Castle #
-  - name: 'UL(M|S) Hoarfrost-GreatForestGorge-LushWoodland patch.esp'
+  - name: 'UL(M|S) Hoarfrost-GreatForestGorge-LushWoodland patch\.esp'
     inc: [ 'LittleSparrowInn.esp' ]
   - name: 'UL(M|S) HoarfrostCastle-LushWoodlands patch.esp'
     req:
       - name: 'HoarfrostCastle.esp'
         display: '[Hoarfrost Castle](https://www.nexusmods.com/oblivion/mods/14714)'
   # ULC Patches - ImpeREAL Empire: Unique Forts #
-  - name: 'UL(M|S) ImpeREALForts-SilverfishRiverValley patch.esp'
+  - name: 'UL(M|S) ImpeREALForts-SilverfishRiverValley patch\.esp'
     req:
       - name: 'ImpeREAL Empire - Unique Forts.esp'
         display: '[ImpeREAL Empire: Unique Forts](https://www.nexusmods.com/oblivion/mods/22965)'
@@ -13744,7 +13744,7 @@ plugins:
         display: '[Integration: The Stranded Light](http://theelderscrolls.info/?go=dlfile&fileid=349) or [Integration - The Stranded Light - Integrated!](http://theelderscrolls.info/?go=dlfile&fileid=441)'
         condition: 'not file("bgIntegrationIntegratedEV.esp") and not file("bgIntegrationDV.esp")'
   # ULC Patches - Kragenir's Death Quest #
-  - name: 'ULE KragenirsDeathQuest.*\patch.esp'
+  - name: 'ULE KragenirsDeathQuest.*patch\.esp'
     req:
       - name: 'Kragenir''s Death Quest.esp'
         display: '[Kragenir''s Death Quest](https://www.nexusmods.com/oblivion/mods/26219)'
@@ -13761,23 +13761,23 @@ plugins:
       - name: 'LostSwordOfTheAylied.esp'
         display: '[Lost Sword of the Ayleids](https://www.nexusmods.com/oblivion/mods/20184)'
   # ULC Patches - MOBS / OMOBS Medieval Oblivion Balance System #
-  - name: 'ULM (MOBS|OMOBS)-UniqueLandscapes patch.esp'
+  - name: 'ULM (MOBS|OMOBS)-UniqueLandscapes patch\.esp'
     req:
       - name: 'Unique Landscapes.esp'
         display: '[Unique Landscapes Compilation](https://www.nexusmods.com/oblivion/mods/19370) Merged ESP'
         condition: 'version("Unique Landscapes.esp", "2.0.0", >=)'
   # ULC Patches - MTC Thieves Grotto #
-  - name: 'UL(E|M|S) MTCThievesGrotto-.*\patch.esp'
+  - name: 'UL(E|M|S) MTCThievesGrotto-.*patch\.esp'
     req:
       - name: 'MTCThievesGrottoV4.1.esp'
         display: '[MTC Thieves Grotto](https://www.nexusmods.com/oblivion/mods/22197)'
   # ULC Patches - Naheema Player Home #
-  - name: 'UL(M|S) PlayerHomeNaheema-ImperialIsle patch.esp'
+  - name: 'UL(M|S) PlayerHomeNaheema-ImperialIsle patch\.esp'
     req:
       - name: 'PlayerHomeNaheema.esp'
         display: '[Naheema Player Home](https://www.nexusmods.com/oblivion/mods/5397)'
   # ULC Patches - Nic-V's Better Beggars #
-  - name: 'UL(M|S) NicVBetterBeggars-BravilBarrowfields patch.esp'
+  - name: 'UL(M|S) NicVBetterBeggars-BravilBarrowfields patch\.esp'
     req:
       - name: 'NBB.esp'
         display: '[Nic-V''s Better Beggars](https://www.nexusmods.com/oblivion/mods/13670)'
@@ -13787,24 +13787,24 @@ plugins:
   - name: 'ULE OblivionUncut-ChorrolHinterland BC6 patch.esp'
     req: [ 'xulChorrolHinterland-BC6.esp' ]
   # ULC Patches - Open Cities Classic #
-  - name: 'UL(E|M|S) OpenCitiesClassic-.*\patch.esp'
+  - name: 'UL(E|M|S) OpenCitiesClassic-.*patch\.esp'
     req:
       - name: 'Open Cities Classic.esp'
         display: '[Open Cities Classic](https://www.nexusmods.com/oblivion/mods/16360)'
   # ULC Patches - Order of the Dragon (Orden des Drachen) #
-  - name: 'UL(M|S) OrdenDesDrachen-JerallGlacier patch.esp'
+  - name: 'UL(M|S) OrdenDesDrachen-JerallGlacier patch\.esp'
     req:
       - name: 'Orden des Drachen.esp'
         display: '[Order of the Dragon](https://www.nexusmods.com/oblivion/mods/45258)'
   # ULC Patches - Oscuro's Oblivion Overhaul (OOO) #
-  - name: 'UL(E|M|S) OscurosOblivionOverhaul-.*\patch.esp'
+  - name: 'UL(E|M|S) OscurosOblivionOverhaul-.*patch\.esp'
     req:
       - name: 'Oscuro''s_Oblivion_Overhaul.esp'
         display: '[Oscuro''s Oblivion Overhaul](https://www.nexusmods.com/oblivion/mods/46199/)'
   # ULC Patches - Pine Lodge #
-  - name: 'UL(M|S) PineLodge-AncientRedwoods patch.esp'
+  - name: 'UL(M|S) PineLodge-AncientRedwoods patch\.esp'
     req: [ 'Pine Lodge.esp' ]
-  - name: 'UL(M|S) PineLodge2-AncientRedwoods patch.esp'
+  - name: 'UL(M|S) PineLodge2-AncientRedwoods patch\.esp'
     req: [ 'Pine Lodge ver2.esp' ]
   # ULC Patches - RealSwords Nord #
   - name: 'ULE RealSwordsNord-Snowdale patch.esp'
@@ -13813,7 +13813,7 @@ plugins:
         display: '[RealSwords Nord](https://www.nexusmods.com/oblivion/mods/23150)'
         condition: 'not file("RealSwords - Nord.*\.esp")'
   # ULC Patches - Reaper's The Dark Tower #
-  - name: 'UL(M|S) ReapersTheDarkTower-BravilBarrowfields patch.esp'
+  - name: 'UL(M|S) ReapersTheDarkTower-BravilBarrowfields patch\.esp'
     req:
       - name: 'Reaper''s The Dark Tower.esp'
         display: '[Reaper''s The Dark Tower](https://www.nexusmods.com/oblivion/mods/31183)'
@@ -13828,7 +13828,7 @@ plugins:
       - name: 'ReclaimSancreTor.esp'
         display: '[Reclaiming Sancre Tor](https://www.nexusmods.com/oblivion/mods/40757)'
   # ULC Patches - Redcourt Castle #
-  - name: 'ULE RedcourtCastle-.*\patch.esp'
+  - name: 'ULE RedcourtCastle-.*patch\.esp'
     req:
       - name: 'RedcourtCastle v1_25.esp'
         display: '[Redcourt Castle](https://www.nexusmods.com/oblivion/mods/14509)'
@@ -13845,12 +13845,12 @@ plugins:
       - 'xulSkingradOutskirts.esp'
     req: [ 'ReclaimSancreTor.esp' ]
   # ULC Patches - Sacryn's Shivering Store #
-  - name: 'UL(M|S) ShiveringStore-BravilBarrowfields patch.esp'
+  - name: 'UL(M|S) ShiveringStore-BravilBarrowfields patch\.esp'
     req:
       - name: 'SSS_1.0.esp'
         display: '[Sacryn''s Shivering Store](https://www.nexusmods.com/oblivion/mods/10528)'
   # ULC Patches - Settlements of Cyrodiil: Clearwater Farms #
-  - name: 'UL(E|M|S) Clearwater-.*\patch.esp'
+  - name: 'UL(E|M|S) Clearwater-.*patch\.esp'
     req:
       - name: 'ClearwaterFarms.esp'
         display: '[Settlements of Cyrodiil: Clearwater Farms](https://www.nexusmods.com/oblivion/mods/45021)'
@@ -13863,12 +13863,12 @@ plugins:
       - 'OrangeInn.esp'
       - 'OrangeInnCOBL.esp'
   # ULC Patches - Settlements of Cyrodiil: Legion Outposts #
-  - name: 'UL(M|S) LegionOutposts-BlackwoodForest patch.esp'
+  - name: 'UL(M|S) LegionOutposts-BlackwoodForest patch\.esp'
     req:
       - name: 'LegionOutposts.esp'
         display: '[Settlements of Cyrodiil: Legion Outposts](https://www.nexusmods.com/oblivion/mods/45059)'
   # ULC Patches - Settlements of Cyrodiil: Oranstad Township #
-  - name: 'UL(E|M|S) Oranstad-.*\patch.esp'
+  - name: 'UL(E|M|S) Oranstad-.*patch\.esp'
     req:
       - name: 'Oranstad.esp'
         display: '[Settlements of Cyrodiil: Oranstad Township](https://www.nexusmods.com/oblivion/mods/45341)'
@@ -13880,7 +13880,7 @@ plugins:
   - name: 'UL(M|S) ShezriesTowns-CloudtopMountains patch.esp'
     inc: [ 'Mimics!.esp' ]
   # ULC Patches - Snow Line Lodge #
-  - name: 'UL(M|S) SnowLineLodge-Snowdale patch.esp'
+  - name: 'UL(M|S) SnowLineLodge-Snowdale patch\.esp'
     req:
       - name: 'Snow Line Lodge.esp'
         display: '[Snow Line Lodge](http://tesalliance.org/forums/index.php?/files/file/4-snow-line-lodge/)'
@@ -13895,7 +13895,7 @@ plugins:
   - name: 'ULE DwarvenMines-UniqueLandscapes merged patch.esp'
     after: [ 'xulAncientYews.esp' ]
   # ULC Patches - The Jerall Mountain Compendium Patch #
-  - name: 'ULE JMC - Layer.*\patch.esp'
+  - name: 'ULE JMC - Layer.*patch\.esp'
     after:
       - name: 'Unique Landscapes.esp'
         condition: 'version("Unique Landscapes.esp", "2.0.0", >=)'
@@ -13931,7 +13931,7 @@ plugins:
         condition: 'file("Unique Landscapes.esp") and version("Unique Landscapes.esp", "2.0.0", >=)'
       - name: 'ULS JMC - Layer 2.esp'
         condition: 'file("xulJerallGlacier.esp")'
-  - name: 'UL(M|S) JMC - Layer 2.esp'
+  - name: 'UL(M|S) JMC - Layer 2\.esp'
     req:
       - name: 'Orden des Drachen.esp'
         display: '[Order of the Dragon](https://www.nexusmods.com/oblivion/mods/45258)'
@@ -13943,7 +13943,7 @@ plugins:
     after:
       - 'ULS GatesToAesgaardEp1-JerallGlacier patch.esp'
       - 'ULS OrdenDesDrachen-JerallGlacier patch.esp'
-  - name: 'UL(M|S) JMC - Layer 3.esp'
+  - name: 'UL(M|S) JMC - Layer 3\.esp'
     after: [ 'DLCFrostcrag Reborn - Frostcrag Village Patch.esp' ]
     req: [ 'ULE JMC - Layer 1.esp' ]
   # ULC Patches - The Golden Arrow Archers Shop #
@@ -13957,21 +13957,21 @@ plugins:
   - name: 'ULE GoldenCrest-UniqueLandscapes merged patch.esp'
     after: [ 'xulSnowdale.esp' ]
   # ULC Patches - The Griffon Fortress #
-  - name: 'UL(M|S) GriffonFortress-EasternPeaks patch.esp'
+  - name: 'UL(M|S) GriffonFortress-EasternPeaks patch\.esp'
     req:
       - name: 'Griffon Fortress 0.3.esp'
         display: '[The Griffon Fortress](https://www.nexusmods.com/oblivion/mods/14830) OR [Griffon Fortress Update](https://www.nexusmods.com/oblivion/mods/24805)'
         condition: 'not file("Griffon Fortress.*\.esp")'
   # ULC Patches - The Hesu Mod Collection #
-  - name: 'UL(M|S) GreatForestGorge-LushWoodlands patch.esp'
+  - name: 'UL(M|S) GreatForestGorge-LushWoodlands patch\.esp'
     inc: [ 'HoarfrostCastle.esp' ]
-  - name: 'UL(M|S) KoyoTown-LushWoodlands patch.esp'
+  - name: 'UL(M|S) KoyoTown-LushWoodlands patch\.esp'
     inc: [ 'ClearwaterFarms.esp' ]
   - name: 'ULE SkyrimTemple-Snowdale patch.esp'
     req:
       - name: 'HESU SkyrimTemple.esp'
         display: '[The Hesu Mod Collection - The Skyrim Temple](https://www.nexusmods.com/oblivion/mods/46090)'
-  - name: 'UL(M|S) SmokeTown-JerallGlacier patch.esp'
+  - name: 'UL(M|S) SmokeTown-JerallGlacier patch\.esp'
     inc: [ 'HESU SkyrimTemple.esp' ]
   # ULC Patches - The Lost Province of Zedar #
   - name: 'ULE Zedar-AncientYews patch.esp'
@@ -13979,7 +13979,7 @@ plugins:
       - name: 'Zedar.esp'
         display: '[The Lost Province of Zedar](https://www.nexusmods.com/oblivion/mods/17018)'
   # ULC Patches - The Lost Spires #
-  - name: 'UL(E|M|S) LostSpires-.*\patch.esp'
+  - name: 'UL(E|M|S) LostSpires-.*patch\.esp'
     req:
       - name: 'The Lost Spires.esp'
         display: '[The Lost Spires](http://www.lostspires.com/pages/downloads.htm)'
@@ -14005,7 +14005,7 @@ plugins:
       - name: 'LanternMonastery.esp'
         display: '[The Temple of Five Lanterns](http://tesalliance.org/forums/index.php?/files/file/238-the-temple-of-five-lanterns/)'
   # ULC Patches - The Warrior's Castle (Die Burg des Kriegers)
-  - name: 'UL(M|S) BergDesKrieger-CloudtopMountains patch.esp'
+  - name: 'UL(M|S) BergDesKrieger-CloudtopMountains patch\.esp'
     req:
       - name: 'Kriegerburg.esp'
         display: '[The Warrior''s Castle (Die Burg des Kriegers)](https://www.elderscrollsportal.de/ressourcen/die-burg-des-kriegers.1042/)'
@@ -14015,7 +14015,7 @@ plugins:
       - name: 'tollingbrookhollowhome.esp'
         display: '[Tollingbrook Hollow Home](https://www.nexusmods.com/oblivion/mods/17509)'
   # ULC Patches - TWMP Skyrim Improved #
-  - name: 'UL(M|S) TWMPSkyrimImproved-JerallGlacier patch.esp'
+  - name: 'UL(M|S) TWMPSkyrimImproved-JerallGlacier patch\.esp'
     req:
       - name: 'treasure maps captus demus.esp'
         display: '[TWMP Skyrim Improved](https://www.nexusmods.com/oblivion/mods/43924)'
@@ -14025,7 +14025,7 @@ plugins:
       - name: 'Unholy Cathedral.esp'
         display: '[Unholy Cathedral](https://www.nexusmods.com/oblivion/mods/24565)'
   # ULC Patches - Windspear Tower #
-  - name: 'UL(M|S) WindspearTower-StendarrValley patch.esp'
+  - name: 'UL(M|S) WindspearTower-StendarrValley patch\.esp'
     req:
       - name: 'aaaWindSpear.esp'
         display: '[A Windspear Tower](https://www.nexusmods.com/oblivion/mods/13171)'


### PR DESCRIPTION
Introduced in #155. These are invalid, but happen to work on py2. Python 3 rejects them, which will make WB refuse to parse the entire masterlist when we get to py3:

```
PS C:\Users\Infernio> py -3
Python 3.9.1 (tags/v3.9.1:1e5d33e, Dec  7 2020, 17:08:21) [MSC v.1927 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> re.compile('UL(E|M|S) .*\patch.esp')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python39\lib\re.py", line 252, in compile
    return _compile(pattern, flags)
  File "C:\Python39\lib\re.py", line 304, in _compile
    p = sre_compile.compile(pattern, flags)
  File "C:\Python39\lib\sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "C:\Python39\lib\sre_parse.py", line 948, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "C:\Python39\lib\sre_parse.py", line 443, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "C:\Python39\lib\sre_parse.py", line 525, in _parse
    code = _escape(source, this, state)
  File "C:\Python39\lib\sre_parse.py", line 426, in _escape
    raise source.error("bad escape %s" % escape, len(escape))
re.error: bad escape \p at position 12
```

Not sure this is the right fix for them though, feel free to close and do your own if it's not the right approach.