### PR TITLE
Replace &useIniTweakOrBashedPatch with &useINITweakInstead

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9252,8 +9252,8 @@ plugins:
   - name: 'Cyrodiil Border Regions 1.2.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/12246' ]
     msg:
-      - type: say
-        content: 'Use .ini tweak or Wrye Bash Bashed Patch tweak instead where possible.'
+      - <<: *useINITweakInstead
+        subs: [ '[bBorderRegionsEnabled=0](http://wiki.tesnexus.com/index.php/Removing_In-Game_Borders)' ]
     dirty:
       - <<: *quickClean
         crc: 0x1BDBE6E9
@@ -16536,11 +16536,17 @@ plugins:
         content: 'Use this without Shivering Isles. Otherwise use ''Merchant_Tim''.'
   - name: 'Borderless Cyrodiil-3578.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/3578' ]
-    msg: [ *useIniTweakOrBashedPatch ]
+    msg:
+      - <<: *useINITweakInstead
+        subs: [ '[bBorderRegionsEnabled=0](http://wiki.tesnexus.com/index.php/Removing_In-Game_Borders)' ]
   - name: 'Border-Region-disabled.esp'
-    msg: [ *useIniTweakOrBashedPatch ]
+    msg:
+      - <<: *useINITweakInstead
+        subs: [ '[bBorderRegionsEnabled=0](http://wiki.tesnexus.com/index.php/Removing_In-Game_Borders)' ]
   - name: 'Border Removal.esp'
-    msg: [ *useIniTweakOrBashedPatch ]
+    msg:
+      - <<: *useINITweakInstead
+        subs: [ '[bBorderRegionsEnabled=0](http://wiki.tesnexus.com/index.php/Removing_In-Game_Borders)' ]
   - name: 'Shadow Ranger.esp'
     msg:
       - <<: *wildEdits

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -457,6 +457,19 @@ common:
     subs: [ '' ]
     condition: 'file("Bashed Patch.*\.esp")'
 
+  - &useINITweakInstead
+    type: say
+    content:
+      - lang: en
+        text: 'An INI tweak can be used instead of this plugin. %1%'
+      - lang: de
+        text: 'Ein INI Tweak kann anstelle dieses Plugins verwendet werden. %1%'
+      - lang: ja
+        text: 'このプラグインの代わりに、INI の調整機能を使用できます。%1%'
+      - lang: sv
+        text: 'En INI Tweak kan användas istället för det här pluginet. %1%'
+    subs: [ '' ]
+
   - &useInstead
     type: warn
     content:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -108,9 +108,6 @@ common:
   - &useWithBashedPatch
     type: say
     content: 'Requires Wrye Bash for compatibility with overhaul mods like OOO/MMM/Fran''s.'
-  - &useIniTweakOrBashedPatch
-    type: warn
-    content: 'Use .ini tweak or Wrye Bash Bashed Patch tweak instead where possible to avoid conflicts.'
 
 # Messages - Localized
   - &alreadyInX


### PR DESCRIPTION
#232

Note that the alias was used incorrectly as the INI tweak in question is not also a Bashed Patch settings tweak but rather a Wrye Bash INI tweak/edit.