### PR TITLE
Add Unofficial Nehrim Fixes

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1479,6 +1479,35 @@ plugins:
     group: *gameMasterGroup
   - name: 'NehrimEnglish.esp'
     after: [ All Natural Nehrim.esp ]
+  - name: 'Unofficial Nehrim Fixes.esp'
+    url: [ 'https://www.nexusmods.com/nehrim/mods/38' ]
+    tag:
+      - Actors.ACBS
+      - Actors.AIData
+      - Actors.AIPackages
+      - Actors.Anims
+      - Actors.RecordFlags
+      - Actors.Spells
+      - Actors.Stats
+      - C.Name
+      - C.RecordFlags
+      - C.Water
+      - Delev
+      - EnchantmentStats
+      - Factions
+      - Graphics
+      - NPC.Class
+      - Names
+      - Scripts
+      - Sound
+      - SpellStats
+      - Stats
+      - Text
+    dirty:
+      - <<: *quickClean
+        crc: 0x630F3440
+        util: '[TES4Edit v4.0.3f](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 1
 
 ###### Modding Tools - Generated Files ######
   - name: 'Bashed Patch.*\.esp'


### PR DESCRIPTION
Acts as an unofficial path, which is why it ends up with so many tags.