### PR TITLE
Add Tag Suggestions To Unofficial Patches

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1286,11 +1286,15 @@ plugins:
       - 'UnRacefix.esp'
       - 'Ultimate_Heist_Fix-4880.esp'
     tag:
+      - Actors.RecordFlags
       - Actors.Spells
       - C.RecordFlags
       - C.Water
       - Graphics
       - Invent.Change
+      - NPC.Eyes
+      - NPC.Hair
+      - NPC.FaceGen
       - Sound
       - SpellStats
       - Text
@@ -1322,12 +1326,15 @@ plugins:
       - 'FormIDReferenceBugFix.esp'
       - 'FormID_Reference_Bug_Fix.esp'
     tag:
+      - Actors.RecordFlags
       - Actors.Skeleton
       - Actors.Spells
       - C.Music
       - C.Water
       - Graphics
       - NPC.Class
+      - NPC.Eyes
+      - NPC.Hair
       - Sound
       - SpellStats
       - Text


### PR DESCRIPTION
`Unofficial Oblivion Patch.esp`
 - Changes Quest Item flag for many NPCs and Creatures. (Actors.RecordFlags)
 - Adds new eyes to NPCs. (NPC.Eyes)
 - Changes hair lenght, adds new hair to NPCs. (NPC.Hair)
 - Changes facegen data for NPCs. (NPC.FaceGen)

`Unofficial Shivering Isles Patch.esp`
 - Adds a Quest Item flag to one Creature. (Actors.RecordFlags).
 - Adds new eyes to NPCs. (NPC.Eyes).
 - Changes hair length, adds new hair to NPCs. (NPC.Hair).