### PR TITLE
Add Sword-Wielding Flame Atronachs

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -23028,3 +23028,17 @@ plugins:
   - name: '000lute.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/4660' ]
     msg: [ *corrupt ]
+
+  - name: 'ZUSwordFlameAtro.*\.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/37239' ]
+  - name: 'ZUSwordFlameAtro_.*\.esp'
+    tag:
+      - Actors.ACBS
+      - Actors.CombatStyle
+      - Actors.Spells
+      - Actors.Stats
+      - Graphics
+      - Invent.Add
+      - Invent.Remove
+      - Scripts
+      - Sound


### PR DESCRIPTION
Contains `ZUSwordFlameAtro.esp`, which needs no tags because it only contains new records and two overrides that change one condition each, and five small patch plugins of the form `ZUSwordFlameAtro_*.esp` that significantly change flame atronachs.