### PR TITLE
Remove theassimilationlab.com urls

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10790,9 +10790,7 @@ plugins:
       - Actors.AIPackages
       - Factions
   - name: 'BrotherhoodRenewed - Oblivion XP Patch.esp'
-    url:
-      - 'https://www.nexusmods.com/oblivion/mods/35333'
-      - 'http://www.theassimilationlab.com/forums/files/file/811-oblivion-xp-patches/'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/35333' ]
     req: [ *OBSE ]
     msg:
       - type: say
@@ -15752,9 +15750,7 @@ plugins:
 
 ###### Better Cities ######
   - name: 'Better (Cities |Imperial City).*\.es(m|p)'
-    url:
-      - 'https://www.nexusmods.com/oblivion/mods/16513'
-      - 'https://www.theassimilationlab.com/forums/files/file/952-better-cities/'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/16513' ]
   - name: 'Better Cities Resources.esm'
     clean:
       - crc: 0x2A37B24E


### PR DESCRIPTION
Since `theassimilationlab.com` apparently shut down the urls no longer work.