### PR TITLE
Drop Ayleid Loot EXtension

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6288,12 +6288,7 @@ plugins:
       - <<: *useInstead
         subs: [ 'Fran-Ayleid Coin Add-on.esp' ]
         condition: 'active("Francesco''s Leveled Creatures-Items Mod.esm")'
-  - name: 'Ayleid Loot EXtension.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/22795' ]
-    req:
-      - name: 'Cobl Main.esm'
-        condition: 'version("Ayleid Loot EXtension.esp","2.11",==)'
-    tag: [ Invent ]
+
   - name: 'aaaBorsBedrolls.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/6430' ]
     tag:


### PR DESCRIPTION
Tag is in the description, Cobl Main.esp is a master of the plugin. Under #24.