### PR TITLE
Replace RustyItems/FineWeapons for OOO entries

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9691,11 +9691,12 @@ plugins:
   - name: 'KDCircletsOOOOptimized - Loot Only.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/10670' ]
     inc: [ 'Potion Belt.esp' ]
-  - name: 'RustyItems for OOO.esp'
+
+  - name: '(RustyItems|FineWeapons) for OOO.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/13302' ]
-    tag:
-      - Graphics
-      - NoMerge
+    req: [ 'Oscuro''s_Oblivion_Overhaul.esm' ]
+    tag: [ Graphics ]
+
   - name: 'BladesSmithySTANDARD.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/8950' ]
     msg:


### PR DESCRIPTION
- Requires OOO, but does not have it as a master.
- Graphics tag, changes models of weapons.
- Changes stats, but those look like outdated forwards from OOO, so I didn't add the Stats tag.
  
Under #24.