### PR TITLE
Replace Blood&Mud entry with new one

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13555,21 +13555,32 @@ plugins:
         <<: *dirtyPlugin
         itm: 5
         udr: 3
+
   - name: 'Blood&Mud.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/12016' ]
-    tag:
-      - Hair
-      - NpcFaces
     msg:
       - <<: *wildEdits
-        subs: [ 'Record names have been changed, you can use the xEdit script **Restore record names from master** to correct them.' ]
-        condition: 'checksum("Blood&Mud.esp", 23A62955)'
+        subs: [ 'Incorrectly renames various records, use the **Restore record names from master** TES4Edit script to fix them.' ]
+        condition: 'checksum("Blood&Mud.esp", 23A62955) or checksum("Blood&Mud.esp", E9B56954)' # Pre- and post-cleaning
     dirty:
       - <<: *quickClean
-        crc: 0xB5963089
-        util: '[TES4Edit v4.0.3](https://www.nexusmods.com/oblivion/mods/11536)'
-        itm: 47
+        crc: 0x23A62955
+        util: '[TES4Edit v4.0.3f](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 36
         udr: 401
+      - <<: *quickClean
+        crc: 0xE11C0D7E
+        util: '[TES4Edit v4.0.3f](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 1
+    tag:
+      - Graphics
+      - Invent.Add
+      - Invent.Remove
+      - NPC.Eyes
+      - NPC.Hair
+      - NPC.FaceGen
+      - R.Hair
+
   - name: 'The Lost Spires.esp'
     url:
       - 'https://www.nexusmods.com/oblivion/mods/12997'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13565,13 +13565,9 @@ plugins:
     dirty:
       - <<: *quickClean
         crc: 0x23A62955
-        util: '[TES4Edit v4.0.3f](https://www.nexusmods.com/oblivion/mods/11536)'
-        itm: 36
+        util: '[TES4Edit v4.0.3](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 37
         udr: 401
-      - <<: *quickClean
-        crc: 0xE11C0D7E
-        util: '[TES4Edit v4.0.3f](https://www.nexusmods.com/oblivion/mods/11536)'
-        itm: 1
     tag:
       - Graphics
       - Invent.Add

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13561,7 +13561,7 @@ plugins:
     msg:
       - <<: *wildEdits
         subs: [ 'Incorrectly renames various records, use the **Restore record names from master** TES4Edit script to fix them.' ]
-        condition: 'checksum("Blood&Mud.esp", 23A62955) or checksum("Blood&Mud.esp", E9B56954)'
+        condition: 'checksum("Blood&Mud.esp", 23A62955) or checksum("Blood&Mud.esp", FAC5765D)'
     dirty:
       - <<: *quickClean
         crc: 0x23A62955

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13562,12 +13562,6 @@ plugins:
       - <<: *wildEdits
         subs: [ 'Incorrectly renames various records, use the **Restore record names from master** TES4Edit script to fix them.' ]
         condition: 'checksum("Blood&Mud.esp", 23A62955) or checksum("Blood&Mud.esp", FAC5765D)'
-    dirty:
-      - <<: *quickClean
-        crc: 0x23A62955
-        util: '[TES4Edit v4.0.3](https://www.nexusmods.com/oblivion/mods/11536)'
-        itm: 37
-        udr: 401
     tag:
       - Graphics
       - Invent.Add
@@ -13576,6 +13570,12 @@ plugins:
       - NPC.Hair
       - NPC.FaceGen
       - R.Hair
+    dirty:
+      - <<: *quickClean
+        crc: 0x23A62955
+        util: '[TES4Edit v4.0.3](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 37
+        udr: 401
 
   - name: 'The Lost Spires.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13561,7 +13561,7 @@ plugins:
     msg:
       - <<: *wildEdits
         subs: [ 'Incorrectly renames various records, use the **Restore record names from master** TES4Edit script to fix them.' ]
-        condition: 'checksum("Blood&Mud.esp", 23A62955) or checksum("Blood&Mud.esp", E9B56954)' # Pre- and post-cleaning
+        condition: 'checksum("Blood&Mud.esp", 23A62955) or checksum("Blood&Mud.esp", E9B56954)'
     dirty:
       - <<: *quickClean
         crc: 0x23A62955


### PR DESCRIPTION
- Has wild edits, renames a couple CELLs and a few other records to weird names (sometimes English, sometimes German).
- Cleaning info from 4.0.3f.
- Tags:
  - Graphics: Changes model (NIFZ) for one CREA
  - Invent.{Add,Remove}: Changes inventories of quite a few NPCs
  - NPC.Eyes: Changes eyes of a few NPCs
  - NPC.{Hair,FaceGen}: Changes the faces for a bunch of NPCs
  - R.Hair: Adds new hairs for a bunch of races
  - Also has some other changes that can be handled by tags, but many look like wild edits (ACBS changes) or would overwrite a bunch of UOP fixes (AIPackages).

Under #24.