### PR TITLE
Drop JQ Fighter's Guild United and related entries

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16549,23 +16549,7 @@ plugins:
             text: 'Do not use if UL Imperial Isle is installed.'
           - lang: de
             text: 'Nicht nutzen wenn UL Imperial Isle installiert ist'
-  - name: '(JQ) Fighters Guild United.esp'
-    tag: [ Invent ]
-  - name: 'JQ-Fighters_Guild_United.esp'
-    tag: [ Invent ]
-  - name: 'JQ-Fighters_guild_united_FR.esp'
-    tag: [ Invent ]
-  - name: '(JQ&SG) Fighters Guild United.esp'
-    tag: [ Invent ]
-  - name: 'FCOM_FighterGUnited.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/15519' ]
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'Requires: Fighters Guild United.'
-          - lang: de
-            text: 'Benötigt: Fighters Guild United.'
+
   - name: 'NPC new clothes V2.6 Modified.esp'
     msg:
       - <<: *renameFile


### PR DESCRIPTION
The original Nexus page for this mod, according to the FCOM patch's page, was this:
https://www.nexusmods.com/oblivion/mods/15186

Gone now, so drop the mod and its patches. Under #24.