### PR TITLE
Replace StarX Vanilla Vampires Revised entry, add OOO patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18321,6 +18321,12 @@ plugins:
       - Actors.Spells
       - Actors.Stats
       - Relations.Change
+  - name: 'StarX VVR_OOO_FCOM Patch.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/42912' ]
+    tag:
+      - Actors.ACBS
+      - Actors.Stats
+      - Relations.Change
 
   - name: 'LTDVampireOverhaul.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/27329' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18301,21 +18301,27 @@ plugins:
       - R.Ears
       - R.Relations
       - R.Teeth
+
   - name: 'StarX Vanilla Vampires Revised.esp'
     url:
       - 'https://www.nexusmods.com/oblivion/mods/16417'
       - 'https://www.nexusmods.com/oblivion/mods/42912'
     msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'Has problems with OOO (StarX vampires will fight OOO vampires, and some chests/weapons will be in skewed places).'
-          - lang: de
-            text: 'Hat Probleme mit OOO (StarX Vampire werden mit OOO Vampiren kämpfen, und einige Truhen/Waffen werden in verstellten Orten sein).'
-        condition: *OOOCond
+      - <<: *obsolete
+        subs: [ '[StarX VVR Updated](https://www.nexusmods.com/oblivion/mods/42912)' ]
+        condition: 'checksum("StarX Vanilla Vampires Revised.esp", B892AF92)'
+      - <<: *patchProvided
+        subs: [ 'FCOM/OOO' ]
+        condition: '(active("FCOM_Convergence.esm") or active("Oscuro''s_Oblivion_Overhaul.esm")) and not active("StarX VVR_OOO_FCOM Patch.esp")'
+      - <<: *wildEdits
+        subs: [ 'Delete the **00023E39** record from this file using TES4Edit.' ]
+        condition: 'checksum("StarX Vanilla Vampires Revised.esp", 6C4E57D4)'
     tag:
-      - C.Light
       - Actors.ACBS
+      - Actors.Spells
+      - Actors.Stats
+      - Relations.Change
+
   - name: 'LTDVampireOverhaul.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/27329' ]
     dirty:


### PR DESCRIPTION
**StarX Vanilla Vampires Revised.esp:**
- Message to use updated version, fixes several issues that make using bash tags with it hard and allows it to work with OOO/FCOM.
- Message to use the OOO/FCOM patch.
- Message to delete a wild edit that will otherwise cause WB to overwrite OOO changes, even with the patch.
- Tags:
  - Actors.ACBS: Present in the description, but the syntax there is wrong, so it doesn't show up in WB.
  - Actors.Spells: Adds spells to vampire NPCs.
  - Actors.Stats: Changes stats of vampire NPCs.
  - Relations.Change: Changes faction relations for vampires.
  - All other required tags are present in the plugin description.

**StarX VVR_OOO_FCOM Patch.esp:**
- Tags:
  - Actors.ACBS: Overwrites StarX vampires' ACBS with OOO's.
  - Actors.Stats: Overwrites StarX vampires' stats with OOO's.
  - Relations.Change: Changes relations in factions added by StarX.
  - All other required tags are present in the plugin description.

Under #24