### PR TITLE
Replace entries for mods included in WEPON with new ones

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -156,6 +156,10 @@ common:
     <<: *alreadyInX
     subs: [ 'FCOM Convergence' ]
     condition: 'active("FCOM_Convergence.esm")'
+  - &alreadyInWEPON
+    <<: *alreadyInX
+    subs: [ 'Weapon Expansion Pack for Oblivion Nthusiasts' ]
+    condition: file("Weapon Expansion Pack for Oblivion Nthusiasts.esp")
 
   - &alreadyInOrFixedByX
     type: error
@@ -7852,9 +7856,12 @@ plugins:
   - name: 'Fighters Guild Scalemail Full.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/14195' ]
     tag: [ Invent ]
+
   - name: 'FineWeapons.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/7317' ]
+    msg: [ *alreadyInWEPON ]
     tag: [ Graphics ]
+
   - name: 'FlameGlassEquipment.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/4000' ]
     tag: [ Graphics ]
@@ -8104,6 +8111,16 @@ plugins:
         util: '[TES4Edit v4.0.3](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 3
         udr: 11
+
+  - name: 'Mithril and Orcish Weapon Sets by Ionis.esp'
+    url: [ 'https://www.nexusmods.com/oblivion/mods/6396' ]
+    msg: [ *alreadyInWEPON ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xD6C2B2AF
+        util: '[TES4Edit v4.0.3f](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 3
+
   - name: 'Nature''s_bounty.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/21618' ]
     dirty:
@@ -8237,9 +8254,12 @@ plugins:
   - name: 'Rune of Independence.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/36694' ]
     req: [ *OBSEv19 ]
+
   - name: 'RustyItems.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/7190' ]
+    msg: [ *alreadyInWEPON ]
     tag: [ Graphics ]
+
   - name: 'RTFemaleReplacerV12.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/15624' ]
     msg:
@@ -9900,13 +9920,9 @@ plugins:
           - lang: de
             text: 'Nur ein IABane Oils X.esp nutzen'
     tag: [ Factions ]
+
   - name: 'Weapon Expansion Pack for Oblivion Nthusiasts.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/35560' ]
-    inc:
-      - 'exhoffhandseries_Ionis_Mithril+Orcish.esp'
-      - 'FineWeapons.esp'
-      - 'Mithril and Orcish Weapon Sets by Ionis.esp'
-      - 'RustyItems.esp'
     tag:
       - Delev
       - Graphics
@@ -9928,6 +9944,7 @@ plugins:
         util: 'TES4Edit v4.0.3f'
       - crc: 0xC35D9987
         util: 'TES4Edit v4.0.3f'
+
   - name: 'Oblivifall - Something''s Not Right.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/27145' ]
     dirty:


### PR DESCRIPTION
* FineWeapons.esp:
  - Message: Already included in WEPON.
  - Tags:
    - Graphics: all it does is change some WEAP models.

* Mithril and Orcish Weapon Sets by Ionis.esp:
  - Message: Already included in WEPON.
  - Tags: None, only adds to leveled lists.
  - Cleaning data: 3 ITMs.

* RustyItems.esp:
  - Message: Already included in WEPON.
  - Tags:
    - Graphics: all it does is change some ARMO and WEAP models.

* Weapon Expansion Pack for Oblivion Nthusiasts.esp:
  - Remove incs, they now duplicate the more specific alreadyInWEPON errors.
  - I couldn't locate exhoffhandseries_Ionis_Mithril+Orcish.esp, which I presume is 'Mithril and Orcish Weapon Sets, by Ionis'. Most likely taken down by the author in favor of version 2 and so can't be located anymore.

Under #24.