### PR TITLE
Replace OCO entry with new one

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2177,7 +2177,10 @@ plugins:
         name: 'Oblivion Character Overhaul v2'
       - link: 'https://www.nexusmods.com/oblivion/mods/48136'
         name: 'Oblivion Character Overhaul v2 - Unofficial Patch'
-    after: [ 'MaleBodyReplacerV5.esp' ]
+    after:
+      - 'MaleBodyReplacerV3.esp'
+      - 'MaleBodyReplacerV4.esp'
+      - 'MaleBodyReplacerV5.esp'
     req:
       - <<: *OBSE
         condition: 'version("Oblivion_Character_Overhaul.esp", "2.0", >=)'
@@ -2185,19 +2188,30 @@ plugins:
         display: '[Blockhead](https://www.nexusmods.com/oblivion/mods/43752)'
         condition: 'version("Oblivion_Character_Overhaul.esp", "2.0", >=)'
     tag:
-      - Body-F
-      - Body-M
-      - Eyes
-      - NpcFaces
+      - Actors.ACBS
+      - Graphics
+      - NPC.Eyes
+      - NPC.FaceGen
+      - NPC.Hair
+      - Body-F # R.Body-F
+      - Body-M # R.Body-M
+      - Body-Size-M # R.Body-Size-M
       - R.Ears
+      - Eyes # R.Eyes
+      - Hair # R.Hair
       - R.Head
       - R.Mouth
     msg:
       - <<: *patch3rdParty
         subs:
-          - 'Wrye Bash Bashed Patch'
+          - 'Wrye Bash''s Bashed Patch'
           - '[OCOv2 - Bashed Patch Eyes Fix](https://www.nexusmods.com/oblivion/mods/49988)'
         condition: 'version("Oblivion_Character_Overhaul.esp", "2.0", >=) and file("Bashed Patch.*\.esp") and not file("OCO_Eyes_Fix.esp")'
+    dirty:
+      - <<: *quickClean
+        crc: 0x5B7D8F89
+        util: '[TES4Edit v4.0.3f](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 2
 
 ###### Encounters - Allies ######
   - name: 'StokerWolff.esp'


### PR DESCRIPTION
- URLs: Link both original and unofficial update.
- Load after all three versions of the male body replacer, otherwise the
  BP will overwrite some of OCO's race changes.
- Requires:
  - OBSE, starting from version 2.
  - Blockhead, starting from version 2.
- Tags:
  - Actors.ACBS: Makes some NPCs female.
  - Graphics: Changes models/icons of some hair and eyes.
  - NPC.{Eyes, FaceGen, Hair}: The point of the mod is changing how NPCs
    look, so these are obviously needed.
  - R.*: Changes a bunch of visuals for races. Also kind of points out
    that we need an R.FaceGen tag for the BP.
- Message: Link the BP Eyes Fix. Would love to fix this for good in WB,
  but I have no idea how 'googly eyes removal' works :/
- Cleaning data: 2 ITMs, an EYES and a HAIR record.

Note that I kept the older names for the R.* tags, because this mod is quite popular and there hasn't been a stable release of WB with the renamed race tags yet.

This reimplements the only contribution by Sctumsempra, meaning we no longer need their approval. Under #24.