### PR TITLE
Update Male Body Replacer v3/4/5

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7354,23 +7354,23 @@ plugins:
     tag:
       - Graphics
       - NoMerge
+
   - name: 'MaleBodyReplacerV3.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/8295' ]
     tag:
-      - Body-M
-      - Body-Size-M
+      - Body-M # R.Body-M
+      - Eyes # R.Eyes
   - name: 'MaleBodyReplacerV4.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/14942' ]
     tag:
-      - Body-M
-      - Body-Size-M
+      - Body-M # R.Body-M
+      - Eyes # R.Eyes
   - name: 'MaleBodyReplacerV5.esp'
     url:
       - 'https://www.nexusmods.com/oblivion/mods/33669'
       - 'https://www.nexusmods.com/oblivion/mods/40532'
-    tag:
-      - Body-M
-      - Body-Size-M
+    tag: [ Body-M ] # R.Body-M
+
   - name: 'bodyshapes.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/36324' ]
     tag:


### PR DESCRIPTION
Extracted from #346.
Tags were wrong, they dont't even touch body sizes. v3 and v4 do, however, remove an eye.

Not sure what to do about the locations - all these plugins have different locations, so I can't add them to the regexes. But adding them to separate entries would leave us with empty entries that only have locations.

Under #24.