### PR TITLE
Replace WCGL entry with new one

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9442,6 +9442,7 @@ plugins:
             text: 'Consider using Creature Diversity.esp or MMM or Frans instead.'
           - lang: de
             text: 'Erwägen Sie stattdessen Creature Diversity.esp oder MMM oder Frans zu nutzen.'
+
   - name: 'WCGL - Wilderness Creatures 1.1.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/1969' ]
     inc:
@@ -9449,6 +9450,19 @@ plugins:
       - 'Francesco''s Leveled Creatures-Items Mod.esm'
       - 'Mart''s Monster Mod.esm'
       - 'Oscuro''s_Oblivion_Overhaul.esp'
+    msg:
+      - <<: *wildEdits
+        subs: [ 'Delete the unused record **01000CE7** using TES4Edit, blocks merging into the Bashed Patch.' ]
+        condition: 'checksum("WCGL - Wilderness Creatures 1.1.esp", 187692FD)'
+    tag:
+      - Delev
+      - Relev
+    dirty:
+      - <<: *quickClean
+        crc: 0x05F50AC9
+        util: '[TES4Edit v4.0.3](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 6
+
   - name: 'Master-Crafting-1.1-MMM.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/19846' ]
     req: [ 'Master-Crafting-1.1-MMM Greaves fix.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9453,7 +9453,7 @@ plugins:
     msg:
       - <<: *wildEdits
         subs: [ 'Delete the unused record **01000CE7** using TES4Edit, blocks merging into the Bashed Patch.' ]
-        condition: 'checksum("WCGL - Wilderness Creatures 1.1.esp", 187692FD)'
+        condition: 'active("Bashed Patch.*\.esp") and checksum("WCGL - Wilderness Creatures 1.1.esp", 187692FD)'
     tag:
       - Delev
       - Relev


### PR DESCRIPTION
- Incompatible with all major overhauls, touches the same leveled lists and simply merging will lead to creatures showing up at the wrong levels.
- Message: Contains an unused record that blocks merging into the BP.
- Tags:
  - Delev: Removes vanilla creatures from leveled lists.
  - Relev: *Shouldn't* actually need it, but because it adds duplicate entries to leveled lists, the BP breaks it without Relev.
- Cleaning data: 6 ITMs. Resulting checksum is the same in both 4.0.3 and 4.0.3f.

This reimplements the last remaining contribution by ZiggyX200. Under #24.