### PR TITLE
Drop Unnecessary Violence entry

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22631,16 +22631,7 @@ plugins:
     msg:
       - <<: *obsolete
         subs: [ '[Unnecessary Violence III](https://www.nexusmods.com/oblivion/mods/40310)' ]
-  - name: 'UnnecessaryViolence.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/24936' ]
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'If using with Supreme Magicka and experiencing frequent swirling pink or green clouds, set ''zzSMConfigurationQuest.bNoPoisonLevitationEffects'' to 1 in SupremeMagicka.ini.'
-          - lang: de
-            text: 'Wenn dies mit Supreme Magicka genutzt wird Sie erleben häufig wirbelnde pinke oder grüne Wolken, setzen Sie ''zzSMConfigurationQuest.bNoPoisonLevitationEffects'' auf 1 in der SupremeMagicka.ini.'
-        condition: 'file("SupremeMagicka.esp")'
+
   - name: 'ptThrowing(Weapons|Knives)\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/23353' ]
     msg:


### PR DESCRIPTION
The original UV hasn't been updated since 2010 and both the mod author and LOOT recommend upgrading to its sequel, UVIII. We already have an `*obsolete` message for this mod, so I'd rather remove this message entirely and rely on the regex entry's message than try reimplementing it.

Under #24 and #321.