### PR TITLE
Remove Extended Cyrodiil EV

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17034,27 +17034,6 @@ plugins:
         itm: 33
         udr: 46
 
-  - name: 'ExtendedAleswellEV.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/38351' ]
-    dirty:
-      - crc: 0x969f8f4b
-        <<: *dirtyPlugin
-        itm: 2
-        udr: 28
-  - name: 'ExtendedBlankenmarchEV.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/38351' ]
-    dirty:
-      - crc: 0x2cb4bb1
-        <<: *dirtyPlugin
-        itm: 7
-        udr: 21
-  - name: 'ExtendedBleakerswayEV.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/38351' ]
-    dirty:
-      - crc: 0x85311f42
-        <<: *dirtyPlugin
-        itm: 39
-        udr: 356
   - name: 'HackdirtAlive.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/42948' ]
     dirty:


### PR DESCRIPTION
#435 
 - Extended Cyrodiil EV was deleted.
 - https://www.nexusmods.com/oblivion/mods/38351/
 - No other source.
 - Original mod Cyrodiil Extended, files have a different name.