### PR TITLE
Remove The Dark Brotherhood Chronicles

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -20180,17 +20180,6 @@ plugins:
             text: 'Use v1.5 or later to avoid extensive compatibility issues.'
           - lang: de
             text: 'Nutzen Sie v1.5 oder neuer um fortgeschrittene Kompatibilitäts-Probleme zu vermeiden.'
-  - name: 'DarkBrotherhoodChronicles.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/41090' ]
-    tag:
-      - Actors.Spells
-      - Actors.AIPackages
-  - name: 'DBC-ImpeREAL City Unique Districts Waterfront Patch.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/41090' ]
-    inc: [ 'DBC-ImpeREAL City Unique Districts-Merged Patch.esp' ]
-  - name: 'DBC-ImpeREAL City Unique Districts-Merged Patch.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/41090' ]
-    inc: [ 'DBC-ImpeREAL City Unique Districts Waterfront Patch.esp' ]
 
   - name: 'Unofficial Elsweyr Anequina Patch.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/39642' ]


### PR DESCRIPTION
Mod Deleted from Nexus Mods, no other source location.
https://www.nexusmods.com/oblivion/mods/41090/