### PR TITLE
Update Servant of the Dawn

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7546,6 +7546,9 @@ plugins:
           - 'Fighter''s Stronghold and Knights of the Nine'
           - '[Servant of the Dawn DLC Compatibility Patch](https://www.nexusmods.com/oblivion/mods/38223/)'
         condition: 'active("DLCBattlehornCastle.esp") and active("Knights.esp") and not file("Servant of the Dawn DLC Compatibility Patch.esp")'
+      - <<: *patchUnavailable
+        subs: [ '[Unofficial Oblivion Patch](https://www.nexusmods.com/oblivion/mods/5296/) **Oblivion Citadel Door Fix.esp**' ]
+        condition: 'file("Oblivion Citadel Door Fix.esp")'
     tag:
       - Actors.AIData
       - Actors.AIPackages


### PR DESCRIPTION
Image of the incompatibility (citadel door is displaced):

![The Elder Scrolls IV Oblivion_2022 01 06-21 03](https://user-images.githubusercontent.com/26516348/148367161-350c154e-3010-44de-bf53-dc2e2fec2010.png)

Cell name: Naghapol.
Cell EditorID: 1SDNaghapol.
Cell FormID: 01080906.