### PR TITLE
Add Shivering Isles - Highcross House

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15372,6 +15372,17 @@ plugins:
         itm: 14
         udr: 109
 
+  - name: 'Highcross House.esp'
+    url:
+      - link: 'https://www.nexusmods.com/oblivion/mods/33569/'
+        name: 'Shivering Isles - Highcross House'
+    req: [ 'DLCShiveringIsles.esp' ]
+    inc: [ 'SICitiesExpanded.esp' ]
+    tag: [ -NoMerge ]
+    clean:
+      - crc: 0x4985A537
+        util: 'TES4Edit v4.0.4b'
+
   - name: 'HilltopLodge.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/42119/' ]
     msg:


### PR DESCRIPTION
Incompatibility with SI Cities Expanded (both full and lite):

![Oblivion20220330 01 17 26](https://user-images.githubusercontent.com/26516348/160643838-2bb86f83-9bde-402e-9fca-1ca362a560a4.jpg)

Without SI Cities Expanded present:

![Oblivion20220330 01 49 56](https://user-images.githubusercontent.com/26516348/160643828-8bb6b8cb-296a-410d-9776-e5317f3bcd8b.jpg)