### PR TITLE
Update Rooftop Rewards - A Treasure Hunting Mod for Acrobats

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1078,7 +1078,9 @@ plugins:
       - link: 'https://tesalliance.org/forums/index.php?/files/file/1296-unofficial-shivering-isles-patch/'
         name: 'Unofficial Shivering Isles Patch (TES Alliance)'
     group: *unofficialPatchesGroup
-    after: [ 'Hidden Treasures.esp' ]
+    after:
+      - 'Hidden Treasures.esp'
+      - 'Rooftop Rewards cleaned.esp'
     inc:
       - 'FormIDReferenceBugFix.esp'
       - 'FormID_Reference_Bug_Fix.esp'
@@ -6275,6 +6277,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/28164/'
         name: 'Rooftop Rewards - A Treasure Hunting Mod for Acrobats'
+    group: *veryEarlyGroup
     req: [ 'DLCShiveringIsles.esp' ]
     dirty:
       - <<: *quickClean


### PR DESCRIPTION
I actually recommend loading this mod BEFORE the Unofficial Shivering Isles Patch. I say this because it will undo some of the fixes in the Unofficial Shivering Isles Patch that cannot be imported by any bash tags. Namely, the music type in Bliss and Crucible will be different.

The mod is only adding new content, so there's no harm in placing it early.