### PR TITLE
Update Stalhrim Village

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14106,7 +14106,13 @@ plugins:
       - link: 'http://tesalliance.org/forums/index.php?/files/file/730-stalhrim-village/'
         name: 'Stalhrim Village'
   - name: 'StalhrimVillage.esp'
+    after: [ 'MannimarcoRevisited.esp' ]
     msg:
+      - <<: *patch3rdParty
+        subs:
+          - 'Mannimarco Revisited'
+          - '[StalhrimVillage-MannimarcoRevisited patch](https://www.nexusmods.com/oblivion/mods/48286/)'
+        condition: 'active("MannimarcoRevisited.esp") and not file("StalhrimVillage-MannimarcoRevisitedpatch.esp")'
       - <<: *patchProvided
         subs: [ 'Weather - All Natural' ]
         condition: 'active("All Natural Base.esm") and not active("StalhrimVillage - AN Patch.esp")'


### PR DESCRIPTION
Default LOOT sorting:

![The Elder Scrolls IV Oblivion_2022 04 10-11 28](https://user-images.githubusercontent.com/26516348/162598135-5afd743e-d605-45f1-985a-13566af3daf5.png)

With after rule added:

![The Elder Scrolls IV Oblivion_2022 04 10-12 07](https://user-images.githubusercontent.com/26516348/162598149-91430eb1-fe8f-4012-a25e-4fe8a989d67b.png)