### PR TITLE
Update Improved NPC Faces for OCOv2

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4385,6 +4385,7 @@ plugins:
       - crc: 0x06D951BD
         util: 'TES4Edit v4.0.4b'
   - name: 'Improved NPC Faces for OCOv2.esp'
+    after: [ 'OCO Cleaned - Vanilla Hair.esp' ]
     inc: [ 'GreyPrince.esp' ]
     clean:
       - crc: 0x76E1B1BF
@@ -4637,9 +4638,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/51324/'
         name: 'Oblivion Character Overhaul Cleaned - OCO Cleaned'
-    before:
-      - 'Improved NPC Faces for OCOv2.esp'
-      - 'OCO Nord and Redguards Eyes Fix.esp'
     msg:
       - <<: *wildEdits
         subs: [ 'Remove **0001D9D8**, **000234B7**, & **00034E7E** from **OCO Cleaned - Vanilla Hair.esp**.' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4637,6 +4637,9 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/51324/'
         name: 'Oblivion Character Overhaul Cleaned - OCO Cleaned'
+    before:
+      - 'Improved NPC Faces for OCOv2.esp'
+      - 'OCO Nord and Redguards Eyes Fix.esp'
     msg:
       - <<: *wildEdits
         subs: [ 'Remove **0001D9D8**, **000234B7**, & **00034E7E** from **OCO Cleaned - Vanilla Hair.esp**.' ]


### PR DESCRIPTION
*Add load order
- OCO Cleaned - Vanilla Hair.esp
Must be load before
- Improved NPC Faces for OCOv2.esp
- OCO Nord and Redguards Eyes Fix.esp

Improved compatibility of "Improved NPC Faces" when using "OCO Cleaned - Vanilla Hair".