### PR TITLE
Update Seamless - OCOv2

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2721,6 +2721,8 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/45859/'
         name: 'Seamless - OCOv2'
+      - link: 'https://www.nexusmods.com/oblivion/mods/51995/'
+        name: 'Seamless - OCOv2 - Version FR'
   - name: 'EVE_StockEquipmentReplacer(4FCOM|4MMM| for OOO)?\.esp'
     msg:
       - <<: *patchIncluded
@@ -2758,11 +2760,19 @@ plugins:
     clean:
       - crc: 0x02EC9CA3
         util: 'TES4Edit v4.0.4b'
+      - crc: 0x40E86E54
+        util: 'TES4Edit v4.0.4b'
+      - crc: 0x9B32BCF3
+        util: 'TES4Edit v4.0.4b'
   - name: 'EVE_ShiveringIslesEasterEggs.esp'
     req: [ 'DLCShiveringIsles.esp' ]
     msg: [ *optional ]
     clean:
       - crc: 0x9409DABA
+        util: 'TES4Edit v4.0.4b'
+      - crc: 0x903EDB5B
+        util: 'TES4Edit v4.0.4b'
+      - crc: 0x43EFF0E0
         util: 'TES4Edit v4.0.4b'
   - name: 'EVE_KnightsoftheNine.esp'
     msg: [ *optional ]
@@ -2772,6 +2782,10 @@ plugins:
       - NoMerge
     clean:
       - crc: 0xA28C2C54
+        util: 'TES4Edit v4.0.4b'
+      - crc: 0x755559E9
+        util: 'TES4Edit v4.0.4b'
+      - crc: 0xADAF9FFC
         util: 'TES4Edit v4.0.4b'
   - name: 'EVE_KhajiitFix.esp'
     inc: [ 'Oblivion_Character_Overhaul.esp' ]


### PR DESCRIPTION
* Add new location
- Seamless - OCOv2 - Version FR:
https://www.nexusmods.com/oblivion/mods/51995/
- Add mod name.

* Add cleaning data
- Seamless - OCOv2 - Version FR v1.1

- EVE_StockEquipmentReplacer.esp:
- Seamless OCOv2 - Version Cleaned: 40E86E54.
- Seamless OCOv2 - Version PNOO: 9B32BCF3.

- EVE_ShiveringIslesEasterEggs.esp:
- Seamless OCOv2 - Version Cleaned: 903EDB5B.
- Seamless OCOv2 - Version PNOO: 43EFF0E0.

- EVE_KnightsoftheNine.esp:
- Seamless OCOv2 - Version Cleaned: 755559E9.
- Seamless OCOv2 - Version PNOO: ADAF9FFC.