### PR TITLE
Add Add some flavor - Talos Bridge

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -20620,6 +20620,16 @@ plugins:
       - crc: 0x47658B0E
         util: 'TES4Edit v4.0.4c'
 
+  - name: 'Add some flavor - Talos bridge.esp'
+    url:
+      - link: 'https://www.nexusmods.com/oblivion/mods/52658/'
+        name: 'Add some flavor - Talos Bridge'
+    req: [ 'DLCShiveringIsles.esp' ]
+    inc: [ 'TalosBridgeGateHouse.esp' ]
+    clean:
+      - crc: 0x2CE1D592
+        util: 'TES4Edit v4.0.4c'
+
   - name: '.*AFK_Weye.*\.esp'
     url:
       - link: 'https://www.afkmods.com/index.php?/files/file/561-afk_weye/'


### PR DESCRIPTION
Incompatible with both Talos Bridge Gatehouse Revisited and the original Talos Bridge Gatehouse mod (overlap in objects and architecture):

![The Elder Scrolls IV Oblivion_2023 03 20-20 41](https://user-images.githubusercontent.com/26516348/226302492-ddd043ac-9dbf-46f1-a167-8ccd5a59b8dd.png)
![The Elder Scrolls IV Oblivion_2023 03 20-20 49](https://user-images.githubusercontent.com/26516348/226303943-0196ff1d-6960-4d86-bf9a-bcbb71181b29.png)