### PR TITLE
Add Cyrodiil Upgrade Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21782,6 +21782,71 @@ plugins:
         itm: 13
         udr: 122
 
+  - name: 'CUO_(BadGuy_Specific_Loot_DIRTY|Bruma|Chorrol|Dwemer|FightersGuildContracts_SAFE|Leyawiin|Transport_SAFE|UnLeveledNPCs&Creatures)\.esp'
+    url:
+      - link: 'https://www.moddb.com/mods/giskards-oblivion-mods/'
+        name: 'Giskard''s Oblivion Mods'
+
+  - name: 'CUO_BadGuy_Specific_Loot_DIRTY.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0xCDDDC092
+        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 3
+
+  - name: 'CUO_Bruma.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0x79E62DCD
+        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 11
+        udr: 5
+
+  - name: 'CUO_Chorrol.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0xA7AF03A3
+        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 32
+        udr: 468
+
+  - name: 'CUO_Dwemer.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0x089C98B3
+        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 18
+
+  - name: 'CUO_FightersGuildContracts_SAFE.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0xE01CE70A
+        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 26
+        udr: 9
+
+  - name: 'CUO_Leyawiin.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0xFF5FEEE3
+        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 30
+        udr: 418
+
+  - name: 'CUO_Transport_SAFE.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0x6CE07196
+        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 82
+
+  - name: 'CUO_UnLeveledNPCs&Creatures.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0xEA16C393
+        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 1
+
   - name: '(DaedraShrinesProdded|KOTNPoked)WithAStick\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/46930/' ]
     tag: [ Actors.AIPackages ]


### PR DESCRIPTION
* Add Plugins: CUO_*x*.esp
  * Place in `###### Locations - Overhauls ######` category

* Add location
  * https://www.moddb.com/mods/giskards-oblivion-mods

* Add cleaning data
  * CUO_Bruma.esp - Version 1.1
  * CUO_Leyawiin.esp - Version 1.4
  * CUO_Chorrol.esp - Version 1.7
  * all other CUO plugins - Version 6.7.1

* Additional information
  * The "Special Versions" of `CUO_Bruma.esp` and `CUO_Leyawiin.esp` are corrupt. I've contemplated to assign the `corrupt` message to the plugins, however LOOT will recognize them being corrupt and remove them from the UI upon sorting plugins. Therefore the extra message isn't needed.