### PR TITLE
Update Unique Landscapes - Imperial Isle and Landscape Fix mod

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1699,6 +1699,10 @@ plugins:
         condition: 'many("(Imperial City|Market District) Landscape Fix\.esp")'
   - name: 'Imperial City Landscape Fix.esp'
     after: [ 'Region Revive - Lake Rumare.esp' ]
+    msg:
+      - <<: *useInstead
+        subs: [ 'Market District Landscape Fix.esp' ]
+        condition: 'active("xulImperialIsle.esp")'
     clean:
       - crc: 0xA8506AD1
         util: 'TES4Edit v4.0.4c'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25598,7 +25598,9 @@ plugins:
         util: 'TES4Edit v4.0.3'
   ### UL Imperial Isle ###
   - name: 'xulImperialIsle.esp'
-    url: [ 'https://www.nexusmods.com/oblivion/mods/9531/' ]
+    url:
+      - link: 'https://www.nexusmods.com/oblivion/mods/9531/'
+        name: 'Unique Landscapes - Imperial Isle'
     after: [ 'road+bridges.esp' ]
     clean:
       - crc: 0x61026078

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25605,7 +25605,9 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/9531/'
         name: 'Unique Landscapes - Imperial Isle'
-    after: [ 'road+bridges.esp' ]
+    after:
+      - 'road+bridges.esp'
+      - 'Add some flavor - city gates.esp'
     clean:
       - crc: 0x61026078
         util: 'TES4Edit v4.0.3'


### PR DESCRIPTION
[Unique Landscapes - Imperial Isle](https://www.nexusmods.com/oblivion/mods/9531/)
[Market District Landscape Fix and Imperial City Landscape Fix](https://www.nexusmods.com/oblivion/mods/50770/)
[Add some flavor - city gates](https://www.nexusmods.com/oblivion/mods/52564/)

According to `crestfallen223` (alias `Troll`) on [Discord](https://discord.com/channels/473542112974077963/473543945188802580/1205625995437150259):
- If `xulImperialIsle.esp` is active, `Market District Landscape Fix.esp` should be used instead of `Imperial City Landscape Fix.esp` .. otherwise `You’ll get a large land tear they conflict heavily`
- Load `xulImperialIsle.esp` after `Add some flavor - city gates.esp`

<img width="886" height="402" alt="image" src="https://github.com/user-attachments/assets/03e4c281-22a2-4128-a226-c23c7580739b" />
