### PR TITLE
Add Immersive Quest Marker Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8251,8 +8251,10 @@ plugins:
     req: [ 'DLCShiveringIsles.esp' ]
 
   - name: 'Immersive Quest Marker Overhaul.esp'
-	url: [ 'https://www.nexusmods.com/oblivion/mods/54007' ]
-	group: *earlyLoadersGroup
+    url:
+      - link: 'https://www.nexusmods.com/oblivion/mods/54007/'
+        name: 'Immersive Quest Marker Overhaul'
+    group: *earlyLoadersGroup
 
   - name: 'Jail Break (Escape )?Routes\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/39385/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8250,6 +8250,10 @@ plugins:
   - name: 'HTSCl_si.esp'
     req: [ 'DLCShiveringIsles.esp' ]
 
+  - name: 'Immersive Quest Marker Overhaul.esp'
+	url: [ 'https://www.nexusmods.com/oblivion/mods/54007' ]
+	group: *earlyLoadersGroup
+
   - name: 'Jail Break (Escape )?Routes\.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/39385/' ]
   - name: 'Jail Break Escape Routes.esp'


### PR DESCRIPTION
The mod will edit quest entries for the majority of vanilla quests, so needs to load early to avoid conflicts.
As UOP/USIP changes are integrated, must be loaded after the patches