### PR TITLE
Update LOD Togglers for Mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1609,6 +1609,7 @@ plugins:
         name: 'LOD Togglers for Mods'
     group: *lodGroup
     msg:
+      - *patchOutdated
       - <<: *disableAfterGeneratingXwithY
         subs:
           - 'DistantLOD'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1609,15 +1609,7 @@ plugins:
         name: 'LOD Togglers for Mods'
     group: *lodGroup
     msg:
-      - *patchOutdated
-      - type: error
-        content:
-          - lang: en
-            text: 'Remove this plugin from your load order after {0} has been generated with {1}.'
-          - lang: bg
-            text: 'Премахнете тази приставка от Вашия ред за зареждане след създаването на "{0}" с {1}.'
-          - lang: de
-            text: 'Entfernen Sie dieses Plugin von Ihrer Ladereihenfolge nachdem {0} generiert wurde mit {1}.'
+      - <<: *disableAfterGeneratingXwithY
         subs:
           - 'DistantLOD'
           - '[TES4LODGen](https://www.nexusmods.com/oblivion/mods/15781/)'


### PR DESCRIPTION
Part of #311

I can't find a suitable replacement for the last 2 messages probably they should be left as is:

`          - lang: en
            text: 'This mod must be activated before you speak to Haskill for the first time.'`

`         - lang: en
            text: 'This file is not required when using Wrye Bash''s Bashed Patch v309+.'`