### PR TITLE
Update &verGreatReqOBSE Sub Anchors

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -563,97 +563,97 @@ common:
     subs:
       - '0010'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.10.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.10.0", <)'
   - &verGreatReqOBSEv11
     <<: *versionXofYorGreaterRequired
     subs:
       - '0011'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.11.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.11.0", <)'
   - &verGreatReqOBSEv12
     <<: *versionXofYorGreaterRequired
     subs:
       - '0012'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.12.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.12.0", <)'
   - &verGreatReqOBSEv13
     <<: *versionXofYorGreaterRequired
     subs:
       - '0013'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.13.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.13.0", <)'
   - &verGreatReqOBSEv14
     <<: *versionXofYorGreaterRequired
     subs:
       - '0014'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.14.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.14.0", <)'
   - &verGreatReqOBSEv15
     <<: *versionXofYorGreaterRequired
     subs:
       - '0015'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.15.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.15.0", <)'
   - &verGreatReqOBSEv16
     <<: *versionXofYorGreaterRequired
     subs:
       - '0016'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.16.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.16.0", <)'
   - &verGreatReqOBSEv17
     <<: *versionXofYorGreaterRequired
     subs:
       - '0017'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.17.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.17.0", <)'
   - &verGreatReqOBSEv18
     <<: *versionXofYorGreaterRequired
     subs:
       - '0018'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.18.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.18.0", <)'
   - &verGreatReqOBSEv19
     <<: *versionXofYorGreaterRequired
     subs:
       - '0019'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.19.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.19.0", <)'
   - &verGreatReqOBSEv20
     <<: *versionXofYorGreaterRequired
     subs:
       - '0020'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.20.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.20.0", <)'
   - &verGreatReqOBSEv21
     <<: *versionXofYorGreaterRequired
     subs:
       - '0021'
       - '[OBSE](https://obse.silverlock.org)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.21.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.21.0", <)'
   - &verGreatReq_xOBSEv21_8
     <<: *versionXofYorGreaterRequired
     subs:
       - '21.8'
       - '[xOBSE](https://github.com/llde/xOBSE/)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.21.8", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.21.8", <)'
   - &verGreatReq_xOBSEv22_1
     <<: *versionXofYorGreaterRequired
     subs:
       - '22.1'
       - '[xOBSE](https://github.com/llde/xOBSE/)'
-    condition: 'version("../obse_1_2_416.dll", "0.0.22.3", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.0.22.3", <)'
   - &verGreatReq_xOBSEv22_6
     <<: *versionXofYorGreaterRequired
     subs:
       - '22.6'
       - '[xOBSE](https://github.com/llde/xOBSE/)'
-    condition: 'version("../obse_1_2_416.dll", "0.22.6.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.22.6.0", <)'
   - &verGreatReq_xOBSEv22_8
     <<: *versionXofYorGreaterRequired
     subs:
       - '22.8'
       - '[xOBSE](https://github.com/llde/xOBSE/)'
-    condition: 'version("../obse_1_2_416.dll", "0.22.8.0", <)'
+    condition: 'file("../Oblivion.exe") and version("../obse_1_2_416.dll", "0.22.8.0", <)'
 
   # &wildEdits
   - &wildEditsRestoreNames


### PR DESCRIPTION
Updates the `condition` to also check for `file("../Oblivion.exe")`, so that Oblivion Remastered plugins (e.g. `Ascension.esp`) that use one of these sub anchors (e.g. `&verGreatReqOBSEv20`) will not display a false error message about OBSE being required.