### PR TITLE
Add xEditQAC error message

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -320,6 +320,13 @@ common:
     name: 'Cobl Main.esm'
     display: '[Common Oblivion (Cobl)](https://www.nexusmods.com/oblivion/mods/21104/)'
 
+# Temporary Message Anchor
+  - &xEditQAC
+    type: error
+    content:
+      - lang: en
+        text: 'xEdit v4.1.5m, v4.1.5n and v4.1.5o have been found to improperly clean Oblivion and Oblivion Remastered plugins. If you have used one of these versions of xEdit to clean this plugin, it is advised to redownload the original plugin.'
+
 # Sub-Anchors
   # &alreadyInX
   - &alreadyInMMM
@@ -866,6 +873,9 @@ plugins:
       - Actors.ACBS
       - Actors.AIPackages
       - Scripts
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("DLCHorseArmor.esp", C8CE448C)'
     dirty:
       - <<: *quickClean
         crc: 0xBAD48E5D
@@ -895,6 +905,9 @@ plugins:
       - Actors.AIPackages
       - C.Light
       - Sound
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("DLCOrrery.esp", 9ECE0AEB)'
     dirty:
       - <<: *quickClean
         crc: 0x5BC59DB4
@@ -930,6 +943,9 @@ plugins:
       - 'KumikoManor.esp'
       - 'Kumiko Manor 2.1 Rus.esp'
     tag: [ Sound ]
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("DLCVileLair.esp", DB162768) or checksum("DLCVileLair.esp", FD28C53F)'
     dirty:
       - <<: *quickClean
         crc: 0x74D2CA6F
@@ -962,6 +978,9 @@ plugins:
     tag:
       - Actors.ACBS
       - Factions
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("DLCMehrunesRazor.esp", 3938FB3B)'
     dirty:
       - <<: *quickClean
         crc: 0xCB413740
@@ -993,6 +1012,9 @@ plugins:
     tag:
       - Actors.Stats
       - Relev
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("DLCSpellTomes.esp", 809BD030) or checksum("DLCSpellTomes.esp", 7D825E81)'
     dirty:
       - <<: *quickClean
         crc: 0x312156F8
@@ -1032,6 +1054,9 @@ plugins:
       - C.Owner
       - C.Water
       - Names
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("DLCThievesDen.esp", 890AE686) or checksum("DLCThievesDen.esp", DB9F0CDE) or checksum("DLCThievesDen.esp", F604A140)'
     dirty:
       - <<: *quickClean
         crc: 0x05DB8CCC
@@ -1065,6 +1090,9 @@ plugins:
         condition: *isOblivion
       - 'Unofficial Oblivion Patch.esp'
     tag: [ Sound ]
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("DLCBattlehornCastle.esp", 614E9114) or checksum("DLCBattlehornCastle.esp", 80DCD920)'
     dirty:
       - <<: *quickClean
         crc: 0x7048C609
@@ -1100,6 +1128,8 @@ plugins:
       - <<: *useInstead
         subs: [ '[Frostcrag Reborn De-Isolated](https://www.nexusmods.com/oblivion/mods/40752/)' ]
         condition: 'version("DLCfrostcrag.esp", "3.0", >=)'
+      - <<: *xEditQAC
+        condition: 'checksum("DLCFrostcrag.esp", 7DDAFD7E) or checksum("DLCFrostcrag.esp", 8549804E)'
     tag:
       - C.Light
       - C.Name
@@ -1143,6 +1173,9 @@ plugins:
       - Invent.Add
       - Invent.Remove
       - Names
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("Knights.esp", A2D15E6C) or checksum("Knights.esp", 6D7758AE) or checksum("Knights.esp", 9C720228)'
     dirty:
       - <<: *quickClean
         crc: 0xF1F478FA
@@ -1160,10 +1193,16 @@ plugins:
   # Oblivion Remastered
   - name: 'AltarESPMain.esp'
     group: *dlcGroup
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("AltarESPMain.esp", 3C1DBD5E) or checksum("AltarESPMain.esp", 0D4258EA)'
   - name: 'AltarESPLocal.esp'
     group: *dlcGroup
   - name: 'AltarDeluxe.esp'
     group: *dlcGroup
+    msg:
+      - <<: *xEditQAC
+        condition: 'checksum("AltarDeluxe.esp", 8EEFBE49) or checksum("AltarDeluxe.esp", 81C43F06)'
   - name: 'AltarGymNavigation.esp'
     group: *dlcGroup
   - name: 'TamrielLeveledRegion.esp'


### PR DESCRIPTION
[Discussion on Discord](https://discord.com/channels/473542112974077963/496196499890241546/1375947754718625812)

![image](https://github.com/user-attachments/assets/44dcc957-9c1b-43c5-a32d-ac3a05aa2b35)

The mentioned issue is gonna be fixed in the upcoming `xEdit v4.1.5p` - once that version does get released, it is likely best to continue to have this message in place for a bit longer. Eventually though, the message can be removed entirely once again.