### PR TITLE
Remove xEditQAC message anchor

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -320,13 +320,6 @@ common:
     name: 'Cobl Main.esm'
     display: '[Common Oblivion (Cobl)](https://www.nexusmods.com/oblivion/mods/21104/)'
 
-# Temporary Message Anchor
-  - &xEditQAC
-    type: error
-    content:
-      - lang: en
-        text: 'xEdit v4.1.5m, v4.1.5n and v4.1.5o have been found to improperly clean Oblivion and Oblivion Remastered plugins. If you have used one of these versions of xEdit to clean this plugin, it is advised to redownload the original plugin.'
-
 # Sub-Anchors
   # &alreadyInX
   - &alreadyInMMM
@@ -896,9 +889,6 @@ plugins:
       - Actors.ACBS
       - Actors.AIPackages
       - Scripts
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("DLCHorseArmor.esp", C8CE448C)'
     dirty:
       - <<: *quickClean
         crc: 0xBAD48E5D
@@ -928,9 +918,6 @@ plugins:
       - Actors.AIPackages
       - C.Light
       - Sound
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("DLCOrrery.esp", 9ECE0AEB)'
     # dirty:
     #   - <<: *quickClean
     #     crc: 0x5BC59DB4
@@ -966,9 +953,6 @@ plugins:
       - 'KumikoManor.esp'
       - 'Kumiko Manor 2.1 Rus.esp'
     tag: [ Sound ]
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("DLCVileLair.esp", DB162768) or checksum("DLCVileLair.esp", FD28C53F)'
     # dirty:
     #   - <<: *quickClean
     #     crc: 0x74D2CA6F
@@ -1001,9 +985,6 @@ plugins:
     tag:
       - Actors.ACBS
       - Factions
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("DLCMehrunesRazor.esp", 3938FB3B)'
     # dirty:
     #   - <<: *quickClean
     #     crc: 0xCB413740
@@ -1035,9 +1016,6 @@ plugins:
     tag:
       - Actors.Stats
       - Relev
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("DLCSpellTomes.esp", 809BD030) or checksum("DLCSpellTomes.esp", 7D825E81)'
     # dirty:
     #   - <<: *quickClean
     #     crc: 0x312156F8
@@ -1077,9 +1055,6 @@ plugins:
       - C.Owner
       - C.Water
       - Names
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("DLCThievesDen.esp", 890AE686) or checksum("DLCThievesDen.esp", DB9F0CDE) or checksum("DLCThievesDen.esp", F604A140)'
     # dirty:
     #   - <<: *quickClean
     #     crc: 0x05DB8CCC
@@ -1113,9 +1088,6 @@ plugins:
         condition: *isOblivion
       - 'Unofficial Oblivion Patch.esp'
     tag: [ Sound ]
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("DLCBattlehornCastle.esp", 614E9114) or checksum("DLCBattlehornCastle.esp", 80DCD920)'
     # dirty:
     #   - <<: *quickClean
     #     crc: 0x7048C609
@@ -1151,8 +1123,6 @@ plugins:
       - <<: *useInstead
         subs: [ '[Frostcrag Reborn De-Isolated](https://www.nexusmods.com/oblivion/mods/40752/)' ]
         condition: 'version("DLCfrostcrag.esp", "3.0", >=)'
-      - <<: *xEditQAC
-        condition: 'checksum("DLCFrostcrag.esp", 7DDAFD7E) or checksum("DLCFrostcrag.esp", 8549804E)'
     tag:
       - C.Light
       - C.Name
@@ -1196,9 +1166,6 @@ plugins:
       - Invent.Add
       - Invent.Remove
       - Names
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("Knights.esp", A2D15E6C) or checksum("Knights.esp", 6D7758AE) or checksum("Knights.esp", 9C720228)'
     # dirty:
     #   - <<: *quickClean
     #     crc: 0xF1F478FA
@@ -1216,16 +1183,10 @@ plugins:
   # Oblivion Remastered
   - name: 'AltarESPMain.esp'
     group: *dlcGroup
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("AltarESPMain.esp", 3C1DBD5E) or checksum("AltarESPMain.esp", 0D4258EA)'
   - name: 'AltarESPLocal.esp'
     group: *dlcGroup
   - name: 'AltarDeluxe.esp'
     group: *dlcGroup
-    msg:
-      - <<: *xEditQAC
-        condition: 'checksum("AltarDeluxe.esp", 8EEFBE49) or checksum("AltarDeluxe.esp", 81C43F06)'
   - name: 'AltarGymNavigation.esp'
     group: *dlcGroup
   - name: 'TamrielLeveledRegion.esp'


### PR DESCRIPTION
Reverts PR https://github.com/loot/oblivion/pull/1911

Since `xEdit v4.1.5p` has been released two months ago on xEdit's Discord server (in the `xedit-builds` channel), this error message is no longer needed.