### PR TITLE
Update Mercer's Ingredient Effect Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8678,6 +8678,7 @@ plugins:
         itm: 50
   - name: 'MercerIngredientsCore.esp'
     after:
+      - 'Cobl Tweaks - OOO.esp'
       - 'Harvest [Flora].esp'
       - 'Salmo The Baker v2.0.esp'
       - 'Salmo the Baker, Cobl.esp'


### PR DESCRIPTION
MercerIngredientsCore makes some changes that Cobl Tweaks overwrites. If the user is using Mercer Ingredients, there is a 100% chance they want its ingredient stats over Cobl Tweaks's.