### PR TITLE
Update cleaning data for official plugins

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -924,6 +924,7 @@ plugins:
         util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 11
         udr: 2
+        condition: *isOblivion
       - <<: *quickClean
         crc: 0x5EF0D503
         util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
@@ -959,6 +960,7 @@ plugins:
         util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 26
         udr: 1
+        condition: *isOblivion
       - <<: *quickClean
         crc: 0x2C59F2F0
         util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
@@ -991,6 +993,7 @@ plugins:
         util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 21
         udr: 15
+        condition: *isOblivion
       - <<: *quickClean
         crc: 0x78FDD06E
         util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
@@ -1021,6 +1024,7 @@ plugins:
         crc: 0x312156F8
         util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 40
+        condition: *isOblivion
       - <<: *quickClean
         crc: 0x4ABF2393
         util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
@@ -1061,6 +1065,7 @@ plugins:
         util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 5
         udr: 135
+        condition: *isOblivion
       - <<: *quickClean
         crc: 0x7BF882E1
         util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
@@ -1094,6 +1099,7 @@ plugins:
         util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 13
         udr: 72
+        condition: *isOblivion
     clean:
       - crc: 0xAA810FEF
         util: 'TES4Edit v4.0.4'
@@ -1136,6 +1142,7 @@ plugins:
         util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 73
         udr: 94
+        condition: *isOblivion
       - <<: *quickClean
         crc: 0x8C95F38D
         util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
@@ -1172,6 +1179,7 @@ plugins:
         util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
         itm: 121
         udr: 255
+        condition: *isOblivion
       - <<: *quickClean
         crc: 0x71480B94
         util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -918,20 +918,20 @@ plugins:
       - Actors.AIPackages
       - C.Light
       - Sound
-    # dirty:
-    #   - <<: *quickClean
-    #     crc: 0x5BC59DB4
-    #     util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 11
-    #     udr: 2
-    #   - <<: *quickClean
-    #     crc: 0x5EF0D503
-    #     util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 11
-    #     udr: 2
-    # clean:
-    #   - crc: 0x351A3894
-    #     util: 'TES4Edit v4.0.4'
+    dirty:
+      - <<: *quickClean
+        crc: 0x5BC59DB4
+        util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 11
+        udr: 2
+      - <<: *quickClean
+        crc: 0x5EF0D503
+        util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 11
+        udr: 2
+    clean:
+      - crc: 0x351A3894
+        util: 'TES4Edit v4.0.4'
   - name: 'DLCVileLair.esp'
     group: *dlcGroup
     after:
@@ -953,20 +953,20 @@ plugins:
       - 'KumikoManor.esp'
       - 'Kumiko Manor 2.1 Rus.esp'
     tag: [ Sound ]
-    # dirty:
-    #   - <<: *quickClean
-    #     crc: 0x74D2CA6F
-    #     util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 26
-    #     udr: 1
-    #   - <<: *quickClean
-    #     crc: 0x2C59F2F0
-    #     util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 28
-    #     udr: 1
-    # clean:
-    #   - crc: 0x8748A782
-    #     util: 'TES4Edit v4.0.4'
+    dirty:
+      - <<: *quickClean
+        crc: 0x74D2CA6F
+        util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 26
+        udr: 1
+      - <<: *quickClean
+        crc: 0x2C59F2F0
+        util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 28
+        udr: 1
+    clean:
+      - crc: 0x8748A782
+        util: 'TES4Edit v4.0.4'
   - name: 'DLCMehrunesRazor.esp'
     group: *dlcGroup
     after:
@@ -985,20 +985,20 @@ plugins:
     tag:
       - Actors.ACBS
       - Factions
-    # dirty:
-    #   - <<: *quickClean
-    #     crc: 0xCB413740
-    #     util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 21
-    #     udr: 15
-    #   - <<: *quickClean
-    #     crc: 0x78FDD06E
-    #     util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 23
-    #     udr: 15
-    # clean:
-    #   - crc: 0x43BCF3D9
-    #     util: 'TES4Edit v4.0.4'
+    dirty:
+      - <<: *quickClean
+        crc: 0xCB413740
+        util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 21
+        udr: 15
+      - <<: *quickClean
+        crc: 0x78FDD06E
+        util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 23
+        udr: 15
+    clean:
+      - crc: 0x43BCF3D9
+        util: 'TES4Edit v4.0.4'
   - name: 'DLCSpellTomes.esp'
     group: *dlcGroup
     after:
@@ -1016,18 +1016,18 @@ plugins:
     tag:
       - Actors.Stats
       - Relev
-    # dirty:
-    #   - <<: *quickClean
-    #     crc: 0x312156F8
-    #     util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 40
-    #   - <<: *quickClean
-    #     crc: 0x4ABF2393
-    #     util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 44
-    # clean:
-    #   - crc: 0x02FA9682
-    #     util: 'TES4Edit v4.0.4'
+    dirty:
+      - <<: *quickClean
+        crc: 0x312156F8
+        util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 40
+      - <<: *quickClean
+        crc: 0x4ABF2393
+        util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 44
+    clean:
+      - crc: 0x02FA9682
+        util: 'TES4Edit v4.0.4'
   - name: 'DLCThievesDen.esp'
     group: *dlcGroup
     after:
@@ -1055,20 +1055,20 @@ plugins:
       - C.Owner
       - C.Water
       - Names
-    # dirty:
-    #   - <<: *quickClean
-    #     crc: 0x05DB8CCC
-    #     util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 5
-    #     udr: 135
-    #   - <<: *quickClean
-    #     crc: 0x7BF882E1
-    #     util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 5
-    #     udr: 135
-    # clean:
-    #   - crc: 0x7F76D2D3
-    #     util: 'TES4Edit v4.0.4'
+    dirty:
+      - <<: *quickClean
+        crc: 0x05DB8CCC
+        util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 5
+        udr: 135
+      - <<: *quickClean
+        crc: 0x7BF882E1
+        util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 5
+        udr: 135
+    clean:
+      - crc: 0x7F76D2D3
+        util: 'TES4Edit v4.0.4'
   - name: 'DLCBattlehornCastle.esp'
     group: *dlcGroup
     after:
@@ -1088,15 +1088,15 @@ plugins:
         condition: *isOblivion
       - 'Unofficial Oblivion Patch.esp'
     tag: [ Sound ]
-    # dirty:
-    #   - <<: *quickClean
-    #     crc: 0x7048C609
-    #     util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 13
-    #     udr: 72
-    # clean:
-    #   - crc: 0xAA810FEF
-    #     util: 'TES4Edit v4.0.4'
+    dirty:
+      - <<: *quickClean
+        crc: 0x7048C609
+        util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 13
+        udr: 72
+    clean:
+      - crc: 0xAA810FEF
+        util: 'TES4Edit v4.0.4'
   - name: 'DLCFrostcrag.esp'
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/9769/'
@@ -1130,20 +1130,20 @@ plugins:
       - C.Regions
       - Factions
       - Sound
-    # dirty:
-    #   - <<: *quickClean
-    #     crc: 0x2A7665FB
-    #     util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 73
-    #     udr: 94
-    #   - <<: *quickClean
-    #     crc: 0x8C95F38D
-    #     util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 74
-    #     udr: 94
-    # clean:
-    #   - crc: 0xF595C8AD
-    #     util: 'TES4Edit v4.0.4'
+    dirty:
+      - <<: *quickClean
+        crc: 0x2A7665FB
+        util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 73
+        udr: 94
+      - <<: *quickClean
+        crc: 0x8C95F38D
+        util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 74
+        udr: 94
+    clean:
+      - crc: 0xF595C8AD
+        util: 'TES4Edit v4.0.4'
   - name: 'Knights.esp'
     group: *dlcGroup
     after:
@@ -1166,20 +1166,20 @@ plugins:
       - Invent.Add
       - Invent.Remove
       - Names
-    # dirty:
-    #   - <<: *quickClean
-    #     crc: 0xF1F478FA
-    #     util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 121
-    #     udr: 255
-    #   - <<: *quickClean
-    #     crc: 0x71480B94
-    #     util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
-    #     itm: 115
-    #     udr: 255
-    # clean:
-    #   - crc: 0xCF02E476
-    #     util: 'TES4Edit v4.0.4'
+    dirty:
+      - <<: *quickClean
+        crc: 0xF1F478FA
+        util: '[TES4Edit v4.1.5n](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 121
+        udr: 255
+      - <<: *quickClean
+        crc: 0x71480B94
+        util: '[TES4Edit v4.0.4](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 115
+        udr: 255
+    clean:
+      - crc: 0xCF02E476
+        util: 'TES4Edit v4.0.4'
   # Oblivion Remastered
   - name: 'AltarESPMain.esp'
     group: *dlcGroup


### PR DESCRIPTION
Reverts https://github.com/loot/oblivion/pull/1919
Ref  https://github.com/loot/oblivion/pull/1221

With the masterlists now using the [new](https://loot-api.readthedocs.io/en/latest/metadata/changelog.html) syntax/branch `v0.29` we are able to assign a `condition` to the cleaning data structure.

As such, add the condition `*isOblivion` to the cleaning data of the official plugins, so that it will only be displayed for Oblivion, but not for Oblivion Remastered.

As a side note, the cleaning data that was added in PR 1221 (so with `TES4Edit v4.0.4`) is for the 1C version of Oblivion, aka "Oblivion Gold Edition", a "disk edition" version of the game, that is widely used in Russia. The CRCs do not match those of "standard" Oblivion, so it doesn't seem necessary to add the new condition to these cleaning data entries as well.