### PR TITLE
Update Faction Relations

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12510,9 +12510,12 @@ plugins:
       - Invent.Remove
       - Relations.Add
       - Relations.Remove
-    clean:
-      - crc: 0x77437CCA
-        util: 'TES4Edit v4.0.4c'
+    dirty:
+      # REVIVED v2.2.1
+      - <<: *quickClean
+        crc: 0x399FE5A2
+        util: '[TES4Edit v4.1.5q](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 1
 
   - name: 'GentlemanBurzGroKhash.esp'
     url: [ 'https://www.nexusmods.com/oblivion/mods/49207/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12504,9 +12504,6 @@ plugins:
           - 'Knights of the Nine - Improved Infamy System'
           - '[Faction Relations - Knights of the Nine Improved Infamy System Patch](https://www.nexusmods.com/oblivion/mods/52023/)'
         condition: 'active("Knights Infamy.esp") and not file("Faction Relations - Improved Knights Infamy Patch.esp")'
-      - <<: *useOnlyOneX
-        subs: [ 'Faction Relations ESP' ]
-        condition: 'many("Faction Relations( - No UOP)?\.esp")'
     tag:
       - Actors.Anims
       - Actors.Factions

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12493,10 +12493,11 @@ plugins:
         itm: 36
         udr: 20
 
-  - name: 'Faction Relations( - No UOP)?\.esp'
+  - name: 'Faction Relations( - KOTNIIS Patch)?\.esp'
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/50868/'
         name: 'Faction Relations'
+  - name: 'Faction Relations.esp'
     msg:
       - <<: *patch3rdParty
         subs:
@@ -12514,13 +12515,8 @@ plugins:
       - Invent.Remove
       - Relations.Add
       - Relations.Remove
-  - name: 'Faction Relations.esp'
     clean:
       - crc: 0x77437CCA
-        util: 'TES4Edit v4.0.4c'
-  - name: 'Faction Relations - No UOP.esp'
-    clean:
-      - crc: 0x8A9A9B6F
         util: 'TES4Edit v4.0.4c'
 
   - name: 'GentlemanBurzGroKhash.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12499,11 +12499,9 @@ plugins:
         name: 'Faction Relations'
   - name: 'Faction Relations.esp'
     msg:
-      - <<: *patch3rdParty
-        subs:
-          - 'Knights of the Nine - Improved Infamy System'
-          - '[Faction Relations - Knights of the Nine Improved Infamy System Patch](https://www.nexusmods.com/oblivion/mods/52023/)'
-        condition: 'active("Knights Infamy.esp") and not file("Faction Relations - Improved Knights Infamy Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Knights of the Nine - Improved Infamy System' ]
+        condition: 'active("Knights Infamy.esp") and not file("Faction Relations - KOTNIIS Patch.esp")'
     tag:
       - Actors.Anims
       - Actors.Factions


### PR DESCRIPTION
Ref [Discord](https://discord.com/channels/473542112974077963/473543945188802580/1518744059462816034)

The linked Discord message is:

> Is this where I can request a change to the masterlist?
> If so, Faction Relations.esp has a notice telling me "You seem to be using **Knights of the Nine - Improved Infamy System**, but you have not enabled a compatibility patch for this mod. A third party patch is available here: [Faction Relations - Knights of the Nine Improved Infamy System Patch](https://www.nexusmods.com/oblivion/mods/52023/)".
> 
> The problem is that the link leads to a mod that has been removed.
> There is a patch available but it's in the optional files section for the Faction Relations mod itself.
> Faction Relations: https://www.nexusmods.com/oblivion/mods/50868
> This is for the original Oblivion.
> 
> -- lord_calvariam in #contributing at 2026-6-22, 3:26 PDT