### PR TITLE
Update Extended Dialogue

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12463,7 +12463,7 @@ plugins:
         name: 'Star''s Extended Dialogue'
     after:
       - 'DialogTweaks.esp'
-      - 'dtaaDialogueTweaks.esp'
+      - 'DialogueEnhancements.esp'
       - 'Oblivion Uncut.esp'
     msg: [ *verGreatReq_xOBSEv21_8 ]
     dirty:


### PR DESCRIPTION
Ref [Discord](https://discord.com/channels/473542112974077963/496196499890241546/1494788555031969974)

The linked Discord message is:

> https://www.nexusmods.com/oblivion/mods/55589?tab=files
> Dialogue tweaks and additions changed its plugin name
> 
> -- yinsolaya in #loot-discussions at 2026-4-17, 12:56 PM PDT