### PR TITLE
Add SI Cities Expanded

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -23094,6 +23094,12 @@ plugins:
       - crc: 0x7E676D2D
         util: 'TES4Edit v4.0.4'
 
+  - name: 'SICitiesExpanded( COM ver)?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/oblivion/mods/51075/'
+        name: 'SI Cities Expanded'
+  - name: 'SICitiesExpanded COM ver.esp'
+
   - name: 'SkingradDeuglified.esp'
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/52456/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -23099,6 +23099,7 @@ plugins:
       - link: 'https://www.nexusmods.com/oblivion/mods/51075/'
         name: 'SI Cities Expanded'
   - name: 'SICitiesExpanded COM ver.esp'
+    after: [ 'CitadelOfMadnessRebirth.esp' ]
 
   - name: 'SkingradDeuglified.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -23098,6 +23098,10 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/51075/'
         name: 'SI Cities Expanded'
+    msg:
+      - <<: *useOnlyOneX
+        subs: [ 'SI Cities Expanded ESP' ]
+        condition: 'many("SICitiesExpanded( COM ver)?\.esp")'
   - name: 'SICitiesExpanded COM ver.esp'
     after: [ 'CitadelOfMadnessRebirth.esp' ]
 


### PR DESCRIPTION
Ref [Discord](https://discord.com/channels/473542112974077963/496196499890241546/1510934373296504914)

The linked Discord message is:

> https://www.nexusmods.com/oblivion/mods/51075?tab=description
> According the author SICItiesExpanded COM ver.esp has to load AFTER the original Citadel of Madness plugin
> 
> -- yinsolaya in #loot-discussions at 2026-6-1, 2:13 AM PDT