### PR TITLE
Update ARO - Ayleid Ruins Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21619,6 +21619,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/50727/'
         name: 'ARO - Ayleid Ruins Overhaul'
+    after: [ 'The Ayleid Steps.esp' ]
     req: [ *MagicExtender ]
     inc: [ 'WSL_Redone.esp' ]
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21639,11 +21639,12 @@ plugins:
       - NPC.Class
       - NPC.FaceGen
     dirty:
+      # 0.2.0
       - <<: *quickClean
-        crc: 0x1D1BE339
-        util: '[TES4Edit v4.0.4c](https://www.nexusmods.com/oblivion/mods/11536)'
-        itm: 128
-        udr: 1209
+        crc: 0xB516DD36
+        util: '[TES4Edit v4.1.5q](https://www.nexusmods.com/oblivion/mods/11536)'
+        itm: 49
+        udr: 674
 
   - name: '(Better Abandoned House|Cheydinhal Land Texture Fix).*\.esp'
     url:


### PR DESCRIPTION
Ref [Discord](https://discord.com/channels/473542112974077963/496196499890241546/1519359679321342063)

The linked Discord message is:

> https://www.nexusmods.com/oblivion/mods/50727
> https://www.nexusmods.com/oblivion/mods/16316
> Ayleid Ruins Overhaul must load AFTER The Ayleid Steps, otherwise, a void in Belda occurs
> 
> -- yinsolaya in #loot-discussions at 2026-6-24, 8:12 AM PDT

![image.png](https://github.com/user-attachments/assets/3cb96712-d88f-46ac-a3cf-1db45077c649)
