### PR TITLE
Add Balanced Creature Stats - Fixed Level Scaling

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11730,6 +11730,27 @@ plugins:
         udr: 1
 
 ###### Gameplay - NPC Balance & Distribution ######
+  - name: 'Balanced Creatures( - DLC)?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/oblivion/mods/49194/'
+        name: 'Balanced Creature Stats - Fixed Level Scaling'
+    tag:
+      - Deactivate
+      - Filter
+      - NoMerge
+  - name: 'Balanced Creatures.esp'
+    after:
+      - name: 'EnhancedGoblinWar.esp'
+        condition: 'file("Bashed Patch.*\.esp")'
+    clean:
+      - crc: 0x8D50EB4A
+        util: 'TES4Edit v4.1.5q'
+  - name: 'Balanced Creatures - DLC.esp'
+    tag: [ -Invent.Remove ]
+    clean:
+      - crc: 0xB0557D0E
+        util: 'TES4Edit v4.1.5q'
+
   - name: 'Battlemages Revised.esp'
     url:
       - link: 'https://www.nexusmods.com/oblivion/mods/48755/'


### PR DESCRIPTION
Ref [Discord](https://discord.com/channels/473542112974077963/496196499890241546/1528176344196845608)

Their linked Discord message and attached image is:

> Enhanced Goblin Wars is overwriting the fatigue changes from Balanced Creature Stats - Fixed Level Scaling
> https://www.nexusmods.com/oblivion/mods/56348
> https://www.nexusmods.com/oblivion/mods/49194
> 
> Load after rules may be needed
> 
> -- yinsolaya in #loot-discussions on 18 July 2026, 11:07 PM GMT
> 
> <img width="1191" height="1024" alt="image" src="https://github.com/user-attachments/assets/01991a67-15fd-4b83-94a6-fc3b9a2efafd" />